### PR TITLE
fix: revert modern union & optional type syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py39"
 exclude = [
     "dist",
     "env",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -7,6 +7,7 @@
   "exclude": [
     "dist",
     "env",
+    ".venv",
     "builds",
     "**/__pycache__",
     "**/*.pyc"
@@ -14,7 +15,7 @@
   "extraPaths": [
     "."
   ],
-  "pythonVersion": "3.11",
+  "pythonVersion": "3.9",
   "typeCheckingMode": "strict",
   "useLibraryCodeForTypes": true,
   "reportMissingImports": "error",

--- a/src/api_client.py
+++ b/src/api_client.py
@@ -18,7 +18,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import asyncio
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 import aiohttp
 from aiohttp import ClientResponse
@@ -32,10 +32,10 @@ class APIClient:
     async def get_api_response(
         self,
         path: str,
-        args: dict[str, Any] | None = None,
-        timeout_sec: int | None = None,
+        args: Optional[dict[str, Any]] = None,
+        timeout_sec: Optional[int] = None,
         retry_count: int = 0,
-        note_id: int | None = None,
+        note_id: Optional[int] = None,
         method: Literal["GET", "POST"] = "POST",
     ) -> ClientResponse:
         if args is None:

--- a/src/app_state.py
+++ b/src/app_state.py
@@ -18,7 +18,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 from copy import deepcopy
-from typing import Any, TypedDict
+from typing import Any, Optional, TypedDict
 
 from .config import config
 from .constants import (
@@ -49,7 +49,7 @@ from .ui.ui_utils import show_message_box
 
 class AppState(TypedDict):
     subscription: SubscriptionState
-    plan: PlanInfo | None
+    plan: Optional[PlanInfo]
 
 
 class AppStateManager:
@@ -86,7 +86,7 @@ class AppStateManager:
             config.auth_token = None
             self._state.update({"subscription": "LOADING", "plan": None})
 
-        def on_new_status(status: UserStatus | None) -> None:
+        def on_new_status(status: Optional[UserStatus]) -> None:
             logger.debug(f"Got new subscription status: {status}")
 
             if not status:
@@ -122,7 +122,7 @@ class AppStateManager:
             use_collection=False,
         )
 
-    def _make_subscription_state(self, sub: PlanInfo | None) -> SubscriptionState:
+    def _make_subscription_state(self, sub: Optional[PlanInfo]) -> SubscriptionState:
         if not sub:
             return "NO_SUBSCRIPTION"
 
@@ -177,7 +177,7 @@ class AppStateManager:
         return did_functionality_degrade
 
     def _handle_subscription_did_transition(
-        self, new_sub: SubscriptionState, plan: PlanInfo | None
+        self, new_sub: SubscriptionState, plan: Optional[PlanInfo]
     ) -> None:
         plan_type = "trial" if "FREE" in new_sub else "paid"
         end_type: str
@@ -192,7 +192,7 @@ class AppStateManager:
             logger.error(f"Unexpected subscription state: {new_sub}")
             return
 
-        err: str | None = None
+        err: Optional[str] = None
         is_api_key = has_api_key()
 
         if end_type == "capacity":
@@ -275,21 +275,21 @@ def is_app_unlocked_or_legacy(show_box: bool = False) -> bool:
     return allowed
 
 
-def did_exceed_image_capacity(sub: PlanInfo | None = None) -> bool:
+def did_exceed_image_capacity(sub: Optional[PlanInfo] = None) -> bool:
     sub = sub or app_state.state["plan"]
     if not sub:
         return False
     return sub["imageCreditsUsed"] >= sub["imageCreditsCapacity"]
 
 
-def did_exceed_text_capacity(sub: PlanInfo | None = None) -> bool:
+def did_exceed_text_capacity(sub: Optional[PlanInfo] = None) -> bool:
     sub = sub or app_state.state["plan"]
     if not sub:
         return False
     return sub["textCreditsUsed"] >= sub["textCreditsCapacity"]
 
 
-def did_exceed_voice_capacity(sub: PlanInfo | None = None) -> bool:
+def did_exceed_voice_capacity(sub: Optional[PlanInfo] = None) -> bool:
     sub = sub or app_state.state["plan"]
     if not sub:
         return False

--- a/src/config.py
+++ b/src/config.py
@@ -21,7 +21,7 @@ import json
 import os
 from collections.abc import Mapping
 from copy import deepcopy
-from typing import Any, TypedDict, TypeVar, cast
+from typing import Any, Optional, TypedDict, TypeVar, cast
 
 from aqt import addons, mw
 
@@ -46,19 +46,19 @@ from .utils import USES_BEFORE_RATE_DIALOG, get_file_path
 class Config:
     """Fancy config class that uses the Anki addon manager to store config values."""
 
-    openai_api_key: str | None
+    openai_api_key: Optional[str]
     prompts_map: PromptMap
     generate_at_review: bool
     times_used: int
-    last_seen_version: str | None
+    last_seen_version: Optional[str]
     uuid: str
-    openai_endpoint: str | None
+    openai_endpoint: Optional[str]
     regenerate_notes_when_batching: bool
     allow_empty_fields: bool
     last_message_id: int
     debug: bool
-    auth_token: str | None
-    legacy_support: bool | None
+    auth_token: Optional[str]
+    legacy_support: Optional[bool]
 
     # Chat
     chat_provider: ChatProviders
@@ -126,7 +126,7 @@ class Config:
         for key, value in defaults.items():
             setattr(self, key, value)
 
-    def _defaults(self) -> dict[str, Any] | None:
+    def _defaults(self) -> Optional[dict[str, Any]]:
         if not mw:
             return {}
 
@@ -218,7 +218,7 @@ M = TypeVar("M", bound=Mapping[str, object])
 
 # TODO: this belongs in utils but ciruclar import
 # TODO: make this use the none_defaulting (too much type golf for now tho)
-def key_or_config_val(vals: M | None, k: str) -> T:  # type: ignore
+def key_or_config_val(vals: Optional[M], k: str) -> T:  # type: ignore
     return (
         cast(T, vals[k])
         if (vals and vals.get(k) is not None)

--- a/src/dag.py
+++ b/src/dag.py
@@ -18,6 +18,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import traceback
+from typing import Optional
 
 from anki.decks import DeckId
 from anki.notes import Note
@@ -34,8 +35,8 @@ def generate_fields_dag(
     note: Note,
     overwrite_fields: bool,
     deck_id: DeckId,
-    target_field: str | None = None,
-    override_prompts_map: PromptMap | None = None,
+    target_field: Optional[str] = None,
+    override_prompts_map: Optional[PromptMap] = None,
 ) -> dict[str, FieldNode]:
     """Generates a directed acyclic graph of prompts for a note, or a subset of that graph if a target_fields list is passed. Returns a mapping of field -> PromptNode"""
     # - Generates all nodes
@@ -152,9 +153,9 @@ def prompt_has_error(
     prompt: str,
     note: Note,
     deck_id: DeckId,
-    target_field: str | None = None,
-    prompts_map: PromptMap | None = None,
-) -> str | None:
+    target_field: Optional[str] = None,
+    prompts_map: Optional[PromptMap] = None,
+) -> Optional[str]:
     """Checks if a prompt has an error. Returns the error message if there is one."""
     note_type = get_note_type(note)
     note_fields = {field.lower() for field in get_fields(note_type)}

--- a/src/field_processor.py
+++ b/src/field_processor.py
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from typing import Optional, Union
+
 from anki.decks import DeckId
 from anki.notes import Note
 from aqt import mw
@@ -71,7 +73,7 @@ class FieldProcessor:
 
     async def resolve(
         self, node: FieldNode, note: Note, show_error_box: bool = False
-    ) -> str | None:
+    ) -> Optional[str]:
         # Only show error box if we're running on the target node
         input = node.input
         field_type: SmartFieldType = node.field_type
@@ -101,7 +103,7 @@ class FieldProcessor:
             should_strip_html: bool = key_or_config_val(extras, "tts_strip_html")
             tts_provider: TTSProviders = key_or_config_val(extras, "tts_provider")
             tts_model: TTSModels = key_or_config_val(extras, "tts_model")
-            tts_voice: OpenAIVoices | ElevenVoices = key_or_config_val(
+            tts_voice: Union[OpenAIVoices, ElevenVoices] = key_or_config_val(
                 extras, "tts_voice"
             )
 
@@ -180,13 +182,13 @@ class FieldProcessor:
         temperature: float,
         should_convert_to_html: bool,
         show_error_box: bool = True,
-    ) -> str | None:
+    ) -> Optional[str]:
         interpolated_prompt = interpolate_prompt(prompt, note)
 
         if not interpolated_prompt:
             return None
 
-        resp: str | None = None
+        resp: Optional[str] = None
 
         if is_app_unlocked():
             if did_exceed_text_capacity():
@@ -235,7 +237,7 @@ class FieldProcessor:
         voice: str,
         strip_html: bool,
         show_error_box: bool = True,
-    ) -> bytes | None:
+    ) -> Optional[bytes]:
         interpolated_prompt = interpolate_prompt(input_text, note)
 
         if not interpolated_prompt:
@@ -265,7 +267,7 @@ class FieldProcessor:
         model: ImageModels,
         provider: ImageProviders,
         show_error_box: bool = True,
-    ) -> bytes | None:
+    ) -> Optional[bytes]:
         if did_exceed_image_capacity():
             logger.debug("App at image capacity, returning early")
             if show_error_box:

--- a/src/hooks.py
+++ b/src/hooks.py
@@ -24,7 +24,7 @@ Setup the hooks for the Anki plugin
 
 import logging
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Optional
 
 from anki.cards import Card
 from anki.notes import Note
@@ -92,7 +92,7 @@ def add_editor_top_button(
 
         # New notes don't have cards yet, fetch into the deck_chooser to get the deckId
         if card is None:
-            deck_id: int | None = None
+            deck_id: Optional[int] = None
             parent = editor.parentWindow
             # Parent should always be AddCards if there's no card
             if isinstance(parent, AddCards):
@@ -201,7 +201,9 @@ def make_on_batch_success(
                 parts.append(f"{pluralize('note', len(skipped))} skipped")
             show_message_box(". ".join(parts) + ".")
         else:
-            show_message_box(f"Processed {pluralize('note', len(updated))} successfully.")
+            show_message_box(
+                f"Processed {pluralize('note', len(updated))} successfully."
+            )
 
     return wrapped_on_batch_success
 

--- a/src/media_utils.py
+++ b/src/media_utils.py
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from typing import Optional
+
 from anki.notes import Note
 from aqt import mw
 
@@ -27,7 +29,7 @@ def get_media_path(note: Note, field: str, format: str) -> str:
     return f"{get_note_type(note)}-{field}-{note.id}.{format}"
 
 
-def write_media(file_name: str, file: bytes) -> str | None:
+def write_media(file_name: str, file: bytes) -> Optional[str]:
     if not mw or not mw.col:
         return None
     media = mw.col.media

--- a/src/models.py
+++ b/src/models.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import Literal, TypedDict
+from typing import Literal, Optional, TypedDict, Union
 
 # Providers
 
@@ -34,8 +34,10 @@ OpenAIModels = Literal[
     "gpt-4o-mini",
 ]
 DeepseekModels = Literal["deepseek-v3"]
-AnthropicModels = Literal["claude-3-5-haiku-latest", "claude-sonnet-4-0", "claude-opus-4-1"]
-ChatModels = OpenAIModels | AnthropicModels | DeepseekModels
+AnthropicModels = Literal[
+    "claude-3-5-haiku-latest", "claude-sonnet-4-0", "claude-opus-4-1"
+]
+ChatModels = Union[OpenAIModels, AnthropicModels, DeepseekModels]
 
 # Order that the models are displayed in the UI
 openai_chat_models: list[ChatModels] = [
@@ -84,7 +86,7 @@ legacy_openai_chat_models: list[str] = [
 OpenAITTSModels = Literal["tts-1"]
 ElevenTTSModels = Literal["eleven_multilingual_v2"]
 GoogleModels = Literal["standard", "wavenet", "neural"]
-TTSModels = OpenAITTSModels | ElevenTTSModels | GoogleModels
+TTSModels = Union[OpenAITTSModels, ElevenTTSModels, GoogleModels]
 
 # TTS Voices
 
@@ -115,20 +117,20 @@ class FieldExtras(TypedDict):
     use_custom_model: bool
 
     # Chat
-    chat_model: ChatModels | None
-    chat_provider: ChatProviders | None
-    chat_temperature: int | None
-    chat_markdown_to_html: bool | None
+    chat_model: Optional[ChatModels]
+    chat_provider: Optional[ChatProviders]
+    chat_temperature: Optional[int]
+    chat_markdown_to_html: Optional[bool]
 
     # TTS
-    tts_provider: TTSProviders | None
-    tts_model: TTSModels | None
-    tts_voice: str | None
-    tts_strip_html: bool | None
+    tts_provider: Optional[TTSProviders]
+    tts_model: Optional[TTSModels]
+    tts_voice: Optional[str]
+    tts_strip_html: Optional[bool]
 
     # Images
-    image_provider: ImageProviders | None
-    image_model: ImageModels | None
+    image_provider: Optional[ImageProviders]
+    image_model: Optional[ImageModels]
 
 
 # Any non-mandatory fields should default to none, and will be displayed from global config instead
@@ -163,12 +165,12 @@ class PromptMap(TypedDict):
 
 # Overridable Options
 
-OverridableChatOptions = (
-    Literal["chat_provider"]
-    | Literal["chat_model"]
-    | Literal["chat_temperature"]
-    | Literal["chat_markdown_to_html"]
-)
+OverridableChatOptions = Union[
+    Literal["chat_provider"],
+    Literal["chat_model"],
+    Literal["chat_temperature"],
+    Literal["chat_markdown_to_html"],
+]
 
 overridable_chat_options: list[OverridableChatOptions] = [
     "chat_provider",
@@ -179,18 +181,18 @@ overridable_chat_options: list[OverridableChatOptions] = [
 
 
 class OverridableChatOptionsDict(TypedDict):
-    chat_provider: ChatProviders | None
-    chat_model: ChatModels | None
-    chat_temperature: int | None
-    chat_markdown_to_html: bool | None
+    chat_provider: Optional[ChatProviders]
+    chat_model: Optional[ChatModels]
+    chat_temperature: Optional[int]
+    chat_markdown_to_html: Optional[bool]
 
 
-OverridableTTSOptions = (
-    Literal["tts_model"]
-    | Literal["tts_provider"]
-    | Literal["tts_voice"]
-    | Literal["tts_strip_html"]
-)
+OverridableTTSOptions = Union[
+    Literal["tts_model"],
+    Literal["tts_provider"],
+    Literal["tts_voice"],
+    Literal["tts_strip_html"],
+]
 
 overridable_tts_options: list[OverridableTTSOptions] = [
     "tts_model",
@@ -201,13 +203,13 @@ overridable_tts_options: list[OverridableTTSOptions] = [
 
 
 class OverrideableTTSOptionsDict(TypedDict):
-    tts_model: TTSModels | None
-    tts_provider: TTSProviders | None
-    tts_voice: str | None
-    tts_strip_html: bool | None
+    tts_model: Optional[TTSModels]
+    tts_provider: Optional[TTSProviders]
+    tts_voice: Optional[str]
+    tts_strip_html: Optional[bool]
 
 
-OverridableImageOptions = Literal["image_provider"] | Literal["image_model"]
+OverridableImageOptions = Union[Literal["image_provider"], Literal["image_model"]]
 overridable_image_options: list[OverridableImageOptions] = [
     "image_model",
     "image_provider",
@@ -215,5 +217,5 @@ overridable_image_options: list[OverridableImageOptions] = [
 
 
 class OverridableImageOptionsDict(TypedDict):
-    image_model: ImageModels | None
-    image_provider: ImageProviders | None
+    image_model: Optional[ImageModels]
+    image_provider: Optional[ImageProviders]

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from typing import Optional
+
 from anki.decks import DeckId
 from attr import dataclass
 
@@ -29,7 +31,7 @@ from .models import SmartFieldType
 class FieldNode:
     field: str
     field_upper: str
-    existing_value: str | None
+    existing_value: Optional[str]
     out_nodes: list["FieldNode"]
     in_nodes: list["FieldNode"]
     manual: bool

--- a/src/note_proccessor.py
+++ b/src/note_proccessor.py
@@ -20,6 +20,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 import asyncio
 import traceback
 from collections.abc import Callable, Sequence
+from typing import Optional
 
 import aiohttp
 from anki.cards import Card, CardId
@@ -59,7 +60,7 @@ class NoteProcessor:
     def process_cards_with_progress(
         self,
         card_ids: Sequence[CardId],
-        on_success: Callable[[list[Note], list[Note], list[Note]], None] | None,
+        on_success: Optional[Callable[[list[Note], list[Note], list[Note]], None]],
         overwrite_fields: bool = False,
     ) -> None:
         """Processes notes in the background with a progress bar, batching into a single undo op"""
@@ -245,9 +246,9 @@ class NoteProcessor:
         show_progress: bool,
         overwrite_fields: bool = False,
         on_success: Callable[[bool], None] = lambda _: None,
-        on_failure: Callable[[Exception], None] | None = None,
-        target_field: str | None = None,
-        on_field_update: Callable[[], None] | None = None,
+        on_failure: Optional[Callable[[Exception], None]] = None,
+        target_field: Optional[str] = None,
+        on_field_update: Optional[Callable[[], None]] = None,
     ):
         """Process a single note, filling in fields with prompts from the user"""
         if not self._assert_preconditions():
@@ -289,8 +290,8 @@ class NoteProcessor:
         note: Note,
         deck_id: DeckId,
         overwrite_fields: bool = False,
-        target_field: str | None = None,
-        on_field_update: Callable[[], None] | None = None,
+        target_field: Optional[str] = None,
+        on_field_update: Optional[Callable[[], None]] = None,
         show_progress: bool = False,
     ) -> bool:
         """Process a single note, returns whether any fields were updated. Optionally can target specific fields. Caller responsible for handling any exceptions."""
@@ -341,7 +342,7 @@ class NoteProcessor:
 
                 responses = await asyncio.gather(*batch_tasks.values())
 
-                for field, response in zip(batch_tasks.keys(), responses, strict=False):
+                for field, response in zip(batch_tasks.keys(), responses):
                     node = dag[field]
                     if response:
                         logger.debug(
@@ -440,7 +441,7 @@ class NoteProcessor:
 
     async def _process_node(
         self, node: FieldNode, note: Note, show_error_message_box: bool
-    ) -> str | None:
+    ) -> Optional[str]:
         if node.abort:
             logger.debug(f"Skipping field {node.field}")
             return None

--- a/src/notes.py
+++ b/src/notes.py
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from typing import Optional
+
 from anki.cards import Card
 from anki.decks import DeckId
 from anki.notes import Note
@@ -70,7 +72,7 @@ def is_card_fully_processed(card: Card) -> bool:
     return True
 
 
-def get_field_from_index(note: Note, index: int) -> str | None:
+def get_field_from_index(note: Note, index: int) -> Optional[str]:
     """Gets the field name from the index of a note."""
     fields = get_fields(get_note_type(note))
     if index < 0 or index >= len(fields):
@@ -79,7 +81,7 @@ def get_field_from_index(note: Note, index: int) -> str | None:
 
 
 # TODO: make this work with get_field_from_index, taking in a field name
-def is_ai_field(current_field_num: int | None, card: Card) -> str | None:
+def is_ai_field(current_field_num: Optional[int], card: Card) -> Optional[str]:
     """Helper to determine if the current field is an AI field. Returns the non-lowercased field name if it is."""
     if not card:
         return None
@@ -129,7 +131,7 @@ def get_chained_ai_fields(note_type: str, deck_id: DeckId) -> set[str]:
     return res
 
 
-def get_random_note(note_type: str, deck_id: DeckId) -> Note | None:
+def get_random_note(note_type: str, deck_id: DeckId) -> Optional[Note]:
     if not mw or not mw.col:
         return None
 
@@ -155,8 +157,8 @@ def get_random_note(note_type: str, deck_id: DeckId) -> Note | None:
 def get_valid_fields_for_prompt(
     selected_note_type: str,
     deck_id: DeckId,
-    selected_note_field: str | None = None,
-    prompts_map: PromptMap | None = None,
+    selected_note_field: Optional[str] = None,
+    prompts_map: Optional[PromptMap] = None,
 ) -> list[str]:
     """Gets all fields excluding the selected one, if one is selected"""
     fields = get_fields(selected_note_type)

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -21,7 +21,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 
 import re
 from copy import deepcopy
-from typing import Any, cast
+from typing import Any, Optional, Union, cast
 
 from anki.decks import DeckId
 from anki.notes import Note
@@ -53,9 +53,9 @@ def get_prompts_for_note(
     note_type: str,
     deck_id: DeckId,
     to_lower: bool = False,
-    override_prompts_map: PromptMap | None = None,
+    override_prompts_map: Optional[PromptMap] = None,
     fallback_to_global_deck: bool = True,
-) -> dict[str, str] | None:
+) -> Optional[dict[str, str]]:
     all_prompts = get_all_prompts(to_lower, override_prompts_map)
     prompts_for_note_type = all_prompts.get(note_type, {})
     deck_prompts = deepcopy(prompts_for_note_type.get(deck_id, {}))
@@ -75,9 +75,9 @@ def get_extras(
     note_type: str,
     field: str,
     deck_id: DeckId,
-    prompts: PromptMap | None = None,
+    prompts: Optional[PromptMap] = None,
     fallback_to_global_deck: bool = True,
-) -> FieldExtras | None:
+) -> Optional[FieldExtras]:
     # Lowercase the field names
     deck_extras = to_lowercase_dict(
         (prompts or config.prompts_map)["note_types"]  # type: ignore
@@ -99,7 +99,7 @@ def get_extras(
 
 
 def get_all_prompts(
-    to_lower: bool = False, override_prompts_map: PromptMap | None = None
+    to_lower: bool = False, override_prompts_map: Optional[PromptMap] = None
 ) -> dict[str, dict[DeckId, dict[str, str]]]:
     """Gets the prompts map. Maps note_type -> deck -> {field -> prompt}"""
     prompts_map = {
@@ -131,7 +131,7 @@ def get_prompt_fields(prompt: str, lower: bool = True) -> list[str]:
     return [(field.lower() if lower else field) for field in fields]
 
 
-def interpolate_prompt(prompt: str, note: Note) -> str | None:
+def interpolate_prompt(prompt: str, note: Note) -> Optional[str]:
     """Interpolates a prompt. Returns none if all source field are empty, or if some are empty and we're not allowing empty fields."""
     # Bunch of extra logic to make this whole process case insensitive
 
@@ -154,7 +154,7 @@ def interpolate_prompt(prompt: str, note: Note) -> str | None:
     values = [all_note_fields.get(field, "") for field in fields]
 
     if any(values) and (allow_empty or all(values)):
-        for field, value in zip(fields, values, strict=False):
+        for field, value in zip(fields, values):
             prompt = prompt.replace("{{" + field + "}}", value)
         return prompt
 
@@ -211,11 +211,11 @@ def add_or_update_prompts(
 
     # If we're doing custom settings, write out extra config
     if is_custom_model:
-        overrideable_options: (
-            OverridableChatOptionsDict
-            | OverridableImageOptionsDict
-            | OverrideableTTSOptionsDict
-        ) = {  # type: ignore
+        overrideable_options: Union[
+            OverridableChatOptionsDict,
+            OverridableImageOptionsDict,
+            OverrideableTTSOptionsDict,
+        ] = {  # type: ignore
             "chat": chat_options,
             "tts": tts_options,
             "image": image_options,

--- a/src/sentry.py
+++ b/src/sentry.py
@@ -24,7 +24,7 @@ import os
 import sys
 import traceback
 from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, Optional
 
 import aiohttp
 import sentry_sdk
@@ -54,7 +54,7 @@ class Sentry:
         logger.debug("Initializing sentry...")
         logger.debug(f"release: {release}, uuid: {uuid}, env: {env}")
 
-        def before_send(event: Any, _: dict[str, Any]) -> Any | None:
+        def before_send(event: Any, _: dict[str, Any]) -> Optional[Any]:
             if not is_production():
                 return None
 
@@ -163,7 +163,7 @@ class Sentry:
 
         return wrapped
 
-    def _get_session(self) -> Session | None:
+    def _get_session(self) -> Optional[Session]:
         _, scope = self.hub._stack[-1]
         return scope._session
 
@@ -222,7 +222,7 @@ def pinger(event: str) -> Callable[[], Coroutine[Any, Any, None]]:
     return ping
 
 
-def init_sentry() -> Sentry | None:
+def init_sentry() -> Optional[Sentry]:
     try:
         if os.getenv("IS_TEST"):
             return None
@@ -256,7 +256,7 @@ sentry = init_sentry()
 def run_async_in_background_with_sentry(
     op: Callable[[], Any],
     on_success: Callable[[Any], None],
-    on_failure: Callable[[Exception], None] | None = None,
+    on_failure: Optional[Callable[[Exception], None]] = None,
     with_progress: bool = False,
     use_collection: bool = True,
 ):

--- a/src/subscription_provider.py
+++ b/src/subscription_provider.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import Literal, TypedDict
+from typing import Literal, Optional, TypedDict, Union
 
 from .api_client import api
 from .config import config
@@ -38,10 +38,10 @@ SubscriptionState = Literal[
 
 
 class PlanInfo(TypedDict):
-    planId: Literal["free"] | str
+    planId: Union[Literal["free"], str]
     planName: str
-    notesUsed: int | None
-    notesLimit: int | None
+    notesUsed: Optional[int]
+    notesLimit: Optional[int]
     daysLeft: int
     textCreditsUsed: int
     textCreditsCapacity: int
@@ -52,8 +52,8 @@ class PlanInfo(TypedDict):
 
 
 class UserStatus(TypedDict):
-    plan: PlanInfo | None
-    error: str | None
+    plan: Optional[PlanInfo]
+    error: Optional[str]
 
 
 class UserInfoProvider:

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -19,7 +19,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Optional
 
 from aqt import mw
 from aqt.operations import QueryOp
@@ -28,7 +28,7 @@ from aqt.operations import QueryOp
 def run_async_in_background(
     op: Callable[[], Any],
     on_success: Callable[[Any], None] = lambda _: None,
-    on_failure: Callable[[Exception], None] | None = None,
+    on_failure: Optional[Callable[[Exception], None]] = None,
     with_progress: bool = False,
     use_collection: bool = True,
 ):

--- a/src/ui/addon_options_dialog.py
+++ b/src/ui/addon_options_dialog.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import Any, TypedDict
+from typing import Any, Optional, TypedDict
 from urllib.parse import urlparse
 
 from aqt import (
@@ -71,15 +71,15 @@ TTS_PROMPT_STUB_VALUE = "🔈"
 
 class State(TypedDict):
     prompts_map: PromptMap
-    selected_row: int | None
+    selected_row: Optional[int]
     generate_at_review: bool
     regenerate_notes_when_batching: bool
-    openai_endpoint: str | None
+    openai_endpoint: Optional[str]
     allow_empty_fields: bool
     debug: bool
 
     # Legacy OpenAI
-    openai_api_key: str | None
+    openai_api_key: Optional[str]
     legacy_openai_model: str
     legacy_openai_models: list[str]
 
@@ -516,7 +516,7 @@ class AddonOptionsDialog(QDialog):
 
         return table
 
-    def on_row_selected(self, current: QTableWidgetItem | None) -> None:
+    def on_row_selected(self, current: Optional[QTableWidgetItem]) -> None:
         if current:
             self.state.update({"selected_row": current.row()})
 

--- a/src/ui/changelog.py
+++ b/src/ui/changelog.py
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from typing import Optional
+
 from aqt import QDialog, QDialogButtonBox, QFont, QLabel, QVBoxLayout, mw
 
 from ..config import config
@@ -115,9 +117,9 @@ def perform_update_check() -> None:
 class ChangeLogDialog(QDialog):
     """Fancy version dialog that shows the changelog since the last version."""
 
-    prior_version: str | None
+    prior_version: Optional[str]
 
-    def __init__(self, prior_version: str | None) -> None:
+    def __init__(self, prior_version: Optional[str]) -> None:
         super().__init__()
         self.prior_version = prior_version
         self.setup_ui()

--- a/src/ui/chat_options.py
+++ b/src/ui/chat_options.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 from aqt import QGroupBox, QLabel, QSpacerItem, QWidget
 
@@ -67,7 +67,7 @@ class ChatOptions(QWidget):
 
     def __init__(
         self,
-        chat_options: OverridableChatOptionsDict | None = None,
+        chat_options: Optional[OverridableChatOptionsDict] = None,
         show_text_processing: bool = True,
     ):
         super().__init__()

--- a/src/ui/custom_prompt.py
+++ b/src/ui/custom_prompt.py
@@ -22,7 +22,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 # existing patterns in the codebase (making heavy use of inheritance, using StateManager in an adhoc-way, etc)
 
 from collections.abc import Callable
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 from anki.decks import DeckId
 from anki.notes import Note
@@ -56,14 +56,14 @@ from .ui_utils import font_small, show_message_box
 
 
 class CustomPrompt(QDialog):
-    _initial_prompt: str | None
+    _initial_prompt: Optional[str]
     _generate_button: QPushButton
     _save_button: QPushButton
     _loading: bool = False
     _prompt_window: QTextEdit
     _note: Note
     _deck_id: DeckId
-    _on_success: Callable[[str | None], None]
+    _on_success: Callable[[Optional[str]], None]
     _field_upper: str
 
     def __init__(
@@ -71,8 +71,8 @@ class CustomPrompt(QDialog):
         note: Note,
         deck_id: DeckId,
         field_upper: str,
-        on_success: Callable[[str | None], None],
-        parent: QWidget | None = None,
+        on_success: Callable[[Optional[str]], None],
+        parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent=parent)
         all_prompts = get_prompts_for_note(
@@ -97,7 +97,7 @@ class CustomPrompt(QDialog):
     def render_custom_model(self) -> QWidget:
         raise Exception("Not implemented")
 
-    def render_to_text(self) -> str | None:
+    def render_to_text(self) -> Optional[str]:
         raise Exception("Not Implemented")
 
     def render_response_box(self) -> QWidget:
@@ -268,7 +268,7 @@ class CustomTextPrompt(CustomPrompt):
     def has_output(self) -> bool:
         return bool(self._response_edit.toPlainText())
 
-    def render_to_text(self) -> str | None:
+    def render_to_text(self) -> Optional[str]:
         return self._response_edit.toPlainText()
 
     def update_ui_states(self) -> None:
@@ -277,7 +277,7 @@ class CustomTextPrompt(CustomPrompt):
 
 class CustomImagePrompt(CustomPrompt):
     response_image: ImageDisplayer
-    raw_image: bytes | None = None
+    raw_image: Optional[bytes] = None
     image_options: ImageOptions
 
     def render_response_box(self) -> QWidget:
@@ -316,7 +316,7 @@ class CustomImagePrompt(CustomPrompt):
     def has_output(self) -> bool:
         return bool(self.raw_image)
 
-    def render_to_text(self) -> str | None:
+    def render_to_text(self) -> Optional[str]:
         if not self.raw_image:
             return None
         file_name = get_media_path(self._note, self._field_upper, "webp")
@@ -334,14 +334,14 @@ class TTSPromptState(TypedDict):
 
 
 class CustomTTSPrompt(CustomPrompt):
-    audio: bytes | None = None
+    audio: Optional[bytes] = None
 
     def __init__(
         self,
         note: Note,
         deck_id: DeckId,
         field_upper: str,
-        on_success: Callable[[str | None], None],
+        on_success: Callable[[Optional[str]], None],
     ) -> None:
         self._note = note
         self._deck_id = deck_id
@@ -377,7 +377,7 @@ class CustomTTSPrompt(CustomPrompt):
                 strip_html=True,
             )
 
-        def on_success(audio: bytes | None):
+        def on_success(audio: Optional[bytes]):
             self._loading = False
             self.audio = audio
 
@@ -404,7 +404,7 @@ class CustomTTSPrompt(CustomPrompt):
     def has_output(self) -> bool:
         return bool(self.audio)
 
-    def render_to_text(self) -> None | str:
+    def render_to_text(self) -> Optional[str]:
         if not self.audio:
             return None
         file_name = get_media_path(self._note, self._field_upper, "mp3")

--- a/src/ui/field_menu.py
+++ b/src/ui/field_menu.py
@@ -18,6 +18,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 from collections.abc import Callable
+from typing import Optional
 
 from anki.cards import Card
 from aqt import QAction, QMenu, browser, editor, mw
@@ -112,8 +113,8 @@ class FieldMenu:
 
     # --------------------- callbacks ----------------------------
 
-    def _make_custom_field_success(self) -> Callable[[str | None], None]:
-        def _on_success(res: str | None) -> None:
+    def _make_custom_field_success(self) -> Callable[[Optional[str]], None]:
+        def _on_success(res: Optional[str]) -> None:
             if res is None:
                 return
 

--- a/src/ui/image_displayer.py
+++ b/src/ui/image_displayer.py
@@ -18,6 +18,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import base64
+from typing import Optional
 
 from aqt import QHBoxLayout, QWebEngineView, QWidget
 from PyQt6.QtCore import Qt
@@ -28,10 +29,10 @@ class ImageDisplayer(QWidget):
 
     def __init__(
         self,
-        image: bytes | None = None,
+        image: Optional[bytes] = None,
         height: int = 500,
         width: int = 500,
-        parent: QWidget | None = None,
+        parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
 

--- a/src/ui/image_options.py
+++ b/src/ui/image_options.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 from aqt import QGroupBox, QVBoxLayout, QWidget
 
@@ -36,7 +36,7 @@ class State(TypedDict):
 
 class ImageOptions(QWidget):
     def __init__(
-        self, image_options: OverridableImageOptionsDict | None = None
+        self, image_options: Optional[OverridableImageOptionsDict] = None
     ) -> None:
         super().__init__()
 

--- a/src/ui/prompt_dialog.py
+++ b/src/ui/prompt_dialog.py
@@ -18,7 +18,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 from collections.abc import Callable
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Literal, Optional, TypedDict, Union, cast
 
 from anki.decks import DeckId
 from anki.notes import Note
@@ -135,9 +135,9 @@ class PromptDialog(QDialog):
         on_accept_callback: Callable[[PromptMap], None],
         field_type: SmartFieldType,
         deck_id: DeckId,
-        card_type: str | None = None,
-        field: str | None = None,
-        prompt: str | None = None,
+        card_type: Optional[str] = None,
+        field: Optional[str] = None,
+        prompt: Optional[str] = None,
     ):
         super().__init__()
 
@@ -568,7 +568,7 @@ class PromptDialog(QDialog):
     def get_tts_prompt(self, source: str) -> str:
         return f"{{{{{source}}}}}"
 
-    def on_target_field_changed(self, field: str | None) -> None:
+    def on_target_field_changed(self, field: Optional[str]) -> None:
         # This shouldn't happen
         if not field:
             return
@@ -668,7 +668,7 @@ class PromptDialog(QDialog):
             else config.tts_model
         ) or config.tts_model
 
-        def on_success(arg: str | bytes | None):
+        def on_success(arg: Union[str, bytes, None]):
             prompt = self.state.s["prompt"]
             if not prompt:
                 return
@@ -772,7 +772,7 @@ class PromptDialog(QDialog):
         self,
         selected_note_type: str,
         deck_id: DeckId,
-        selected_note_field: str | None = None,
+        selected_note_field: Optional[str] = None,
     ) -> list[str]:
         """Gets all fields excluding selected and existing prompts"""
         all_valid_fields = get_valid_fields_for_prompt(
@@ -814,7 +814,7 @@ class PromptDialog(QDialog):
             "No valid source fields remaining",
         )
 
-    def _attempt_to_parse_source_field(self, prompt: str) -> str | None:
+    def _attempt_to_parse_source_field(self, prompt: str) -> Optional[str]:
         fields = get_prompt_fields(prompt, lower=False)
 
         if len(fields) != 1:

--- a/src/ui/reactive_combo_box.py
+++ b/src/ui/reactive_combo_box.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from aqt import QComboBox
 
@@ -36,7 +36,7 @@ class ReactiveComboBox(ReactiveWidget[T], QComboBox, Generic[T]):
         state: StateManager[T],
         fields_key: str,
         selected_key: str,
-        render_map: dict[str, str] | None = None,
+        render_map: Optional[dict[str, str]] = None,
         # Internally can't use int bc huge ints will cause overflow (thx insane anki deck ids), but
         # pretend to outside consumers
         int_keys: bool = False,

--- a/src/ui/subscription_box.py
+++ b/src/ui/subscription_box.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypedDict, Union
 
 from aqt import (
     QGroupBox,
@@ -47,7 +47,7 @@ from .webview_dialog import WebviewDialog
 
 
 class State(TypedDict):
-    subscription: SubscriptionState | Literal["Loading"]
+    subscription: Union[SubscriptionState, Literal["Loading"]]
 
 
 start_trial_style = """
@@ -127,7 +127,7 @@ class SubscriptionBox(QWidget):
     def __init__(self) -> None:
         super().__init__()
 
-        self.ui_map: dict[SubscriptionState | Literal["Loading"], QWidget] = {
+        self.ui_map: dict[Union[SubscriptionState, Literal["Loading"]], QWidget] = {
             "LOADING": self._render_loading(),
             "UNAUTHENTICATED": self._render_start_trial(),
             "NO_SUBSCRIPTION": self._render_start_trial(),

--- a/src/ui/tts_options.py
+++ b/src/ui/tts_options.py
@@ -18,7 +18,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import json
-from typing import Literal, TypedDict, cast
+from typing import Literal, Optional, TypedDict, Union, cast
 
 from aqt import (
     QAbstractListModel,
@@ -57,7 +57,7 @@ from .ui_utils import default_form_layout, font_small, show_message_box
 
 ALL: Literal["All"] = "All"
 
-AllTTSProviders = Literal["All"] | TTSProviders
+AllTTSProviders = Union[Literal["All"], TTSProviders]
 
 Gender = Literal["All", "Male", "Female"]
 default_texts: dict[str, str] = {
@@ -262,7 +262,7 @@ class TTSOptions(QWidget):
 
     def __init__(
         self,
-        tts_options: OverrideableTTSOptionsDict | None = None,
+        tts_options: Optional[OverrideableTTSOptionsDict] = None,
         extras_visible: bool = True,
     ):
         super().__init__()
@@ -491,7 +491,7 @@ class TTSOptions(QWidget):
         return filtered
 
     def get_initial_state(
-        self, tts_options: OverrideableTTSOptionsDict | None
+        self, tts_options: Optional[OverrideableTTSOptionsDict]
     ) -> TTSState:
         ret = {
             "providers": providers,

--- a/src/ui/ui_utils.py
+++ b/src/ui/ui_utils.py
@@ -17,13 +17,15 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from typing import Optional
+
 from aqt import QFont, QFormLayout, QMessageBox, QPushButton, Qt
 
 
 def show_message_box(
     message: str,
-    details: str | None = None,
-    custom_ok: str | None = None,
+    details: Optional[str] = None,
+    custom_ok: Optional[str] = None,
     show_cancel: bool = False,
 ):
     msg = QMessageBox()

--- a/src/ui/webview_dialog.py
+++ b/src/ui/webview_dialog.py
@@ -18,7 +18,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import time
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import urlencode
 
 from aqt import (
@@ -70,7 +70,7 @@ class WebviewDialog(QDialog):
         self,
         parent: QWidget,
         path: str = "",
-        query_params: dict[str, str] | None = None,
+        query_params: Optional[dict[str, str]] = None,
     ) -> None:
         if query_params is None:
             query_params = {}


### PR DESCRIPTION
modern pipe based union type syntax was breaking anki versions with python 3.9