### PR TITLE
chore: upgrade sentry-sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ requests-toolbelt==1.0.0
 rpds-py==0.18.1
 ruff==0.6.3
 Send2Trash==1.8.3
-sentry-sdk==2.5.1
+sentry-sdk==2.35.0
 sniffio==1.3.1
 soupsieve==2.5
 tqdm==4.66.4


### PR DESCRIPTION
Probably fixes the FrameLocalsProxy error

https://github.com/BerriAI/litellm/issues/8080