### PR TITLE
refactor: collapse CORS/preflight duplication in local_server

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,6 +50,7 @@ build () {
     "certifi"
     "urllib3"
     "dotenv"
+    "dacite"
   )
 
   # copy them in a loop

--- a/src/local_server.py
+++ b/src/local_server.py
@@ -17,13 +17,20 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+# ruff: noqa: N815
+#
+# Request/response dataclasses mirror a camelCase JSON wire contract; dacite
+# maps dict keys directly to dataclass field names, so the fields must match.
+
 import asyncio
 import concurrent.futures
 import threading
 import traceback
-from collections.abc import Mapping
-from typing import Any, Optional, TypedDict, cast
+from collections.abc import Awaitable
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
+import dacite
 from aiohttp import web
 from anki.decks import DeckId
 from anki.notes import NoteId
@@ -35,17 +42,11 @@ from .config import config
 from .constants import GLOBAL_DECK_ID, SITE_URL_DEV
 from .logger import logger
 from .models import (
-    ChatModels,
-    ChatProviders,
     FieldExtras,
-    ImageModels,
-    ImageProviders,
     OverridableChatOptionsDict,
     OverridableImageOptionsDict,
     OverrideableTTSOptionsDict,
     SmartFieldType,
-    TTSModels,
-    TTSProviders,
 )
 from .note_proccessor import NoteProcessor
 from .notes import get_fields
@@ -58,148 +59,18 @@ from .prompts import (
 from .sentry import sentry
 from .ui.prompt_dialog import PromptDialog
 
-# -- Request param types --
-
-
-class GetSmartFieldsParams(TypedDict, total=False):
-    noteType: str  # required
-    deckId: int
-
-
-class ChatOptionsParams(TypedDict, total=False):
-    provider: ChatProviders
-    model: ChatModels
-    temperature: int
-    markdownToHtml: bool
-    webSearch: bool
-
-
-class TTSOptionsParams(TypedDict, total=False):
-    provider: TTSProviders
-    model: TTSModels
-    voice: str
-    stripHtml: bool
-
-
-class ImageOptionsParams(TypedDict, total=False):
-    provider: ImageProviders
-    model: ImageModels
-
-
-class SmartFieldParams(TypedDict, total=False):
-    noteType: str  # required
-    field: str  # required
-    prompt: str  # required
-    type: SmartFieldType
-    deckId: int
-    automatic: bool
-    useCustomModel: bool
-    chatOptions: ChatOptionsParams
-    ttsOptions: TTSOptionsParams
-    imageOptions: ImageOptionsParams
-
-
-class RemoveSmartFieldParams(TypedDict, total=False):
-    noteType: str  # required
-    field: str  # required
-    deckId: int
-
-
-class GenerateNoteParams(TypedDict, total=False):
-    noteId: int  # required
-    deckId: int
-    overwrite: bool
-    targetField: str
-
-
-class GenerateNotesParams(TypedDict, total=False):
-    noteIds: list[int]  # required
-    deckId: int
-    overwrite: bool
-
-
-# -- Response types --
-
-
-class SmartFieldInfo(TypedDict):
-    prompt: str
-    extras: Optional[FieldExtras]
-
-
-class GenerateNoteResult(TypedDict):
-    updated: bool
-    fields: dict[str, str]
-
-
-class GenerateNotesResult(TypedDict):
-    updated: list[int]
-    failed: list[int]
-    skipped: list[int]
-
-
-class ApiResponse(TypedDict):
-    result: Any
-    error: Optional[str]
-
-
-LOCAL_SERVER_PORT = 8766
-LOCAL_SERVER_HOST = "127.0.0.1"
-API_VERSION = 1
-
-ALLOWED_ORIGINS = {
-    "https://smart-notes.xyz",
-    "https://www.smart-notes.xyz",
-    SITE_URL_DEV,
-}
-
-
-def _run_on_main_sync(fn: Any) -> Any:
-    if not mw:
-        raise RuntimeError("mw not available")
-    future: concurrent.futures.Future[Any] = concurrent.futures.Future()
-
-    def work() -> None:
-        try:
-            future.set_result(fn())
-        except Exception as e:
-            future.set_exception(e)
-
-    mw.taskman.run_on_main(work)
-    return future.result(timeout=30)
-
-
-def _ok(result: Any) -> ApiResponse:
-    return {"result": result, "error": None}
-
-
-def _err(message: str) -> ApiResponse:
-    return {"result": None, "error": message}
-
-
-def _get_deck_id(params: Mapping[str, Any]) -> DeckId:
-    raw = params.get("deckId")
-    if raw is None:
-        return GLOBAL_DECK_ID
-    return cast(DeckId, int(raw))
+# -- Public API --------------------------------------------------------------
 
 
 class LocalServer:
+    """Background aiohttp server that exposes the add-on to the signup web
+    flow (CORS'd endpoints) and to local tooling (the `/` RPC dispatch)."""
+
     def __init__(self, processor: NoteProcessor) -> None:
         self._processor = processor
         self._thread: Optional[threading.Thread] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._runner: Optional[web.AppRunner] = None
-        self._actions: dict[str, Any] = {
-            "ping": self._handle_ping,
-            "getSmartFields": self._handle_get_smart_fields,
-            "addSmartField": self._handle_add_smart_field,
-            "updateSmartField": self._handle_update_smart_field,
-            "removeSmartField": self._handle_remove_smart_field,
-            "generateNote": self._handle_generate_note,
-            "generateNotes": self._handle_generate_notes,
-            "uiEditSmartField": self._handle_ui_edit_smart_field,
-            "uiNewSmartField": self._handle_ui_new_smart_field,
-        }
 
     def start(self) -> None:
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -217,18 +88,11 @@ class LocalServer:
     def _run(self) -> None:
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
-        self._loop.run_until_complete(self._start_server())
+        self._loop.run_until_complete(self._serve())
         self._loop.run_forever()
 
-    async def _start_server(self) -> None:
-        app = web.Application()
-        app.router.add_post("/", self._handle_request)
-        app.router.add_post("/auth/callback", self._handle_auth_callback)
-        app.router.add_options("/auth/callback", self._handle_auth_preflight)
-        app.router.add_post("/subscription/refresh", self._handle_subscription_refresh)
-        app.router.add_options("/subscription/refresh", self._handle_auth_preflight)
-        app.router.add_get("/ping", self._handle_loopback_ping)
-        app.router.add_options("/ping", self._handle_ping_preflight)
+    async def _serve(self) -> None:
+        app = build_app(self._processor)
         self._runner = web.AppRunner(app)
         await self._runner.setup()
         try:
@@ -244,411 +108,683 @@ class LocalServer:
                 f"Local server failed to bind {LOCAL_SERVER_HOST}:{LOCAL_SERVER_PORT}: {e}"
             )
 
-    def _cors_headers(self, origin: str) -> dict[str, str]:
-        # Only called once origin is confirmed to be in ALLOWED_ORIGINS.
-        return {
-            "Access-Control-Allow-Origin": origin,
-            "Access-Control-Allow-Methods": "POST, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type",
-            "Access-Control-Allow-Private-Network": "true",
-            "Access-Control-Max-Age": "600",
-            "Vary": "Origin",
-        }
 
-    async def _handle_auth_preflight(self, request: web.Request) -> web.Response:
-        origin = request.headers.get("Origin")
-        if origin not in ALLOWED_ORIGINS:
+def build_app(processor: NoteProcessor) -> web.Application:
+    """Construct the aiohttp Application. Exposed for tests."""
+    app = web.Application(middlewares=[cors_middleware])
+    _register_routes(app, processor)
+    return app
+
+
+# -- Constants ---------------------------------------------------------------
+
+
+LOCAL_SERVER_PORT = 8766
+LOCAL_SERVER_HOST = "127.0.0.1"
+API_VERSION = 1
+
+ALLOWED_ORIGINS: frozenset[str] = frozenset(
+    {
+        "https://smart-notes.xyz",
+        "https://www.smart-notes.xyz",
+        SITE_URL_DEV,
+    }
+)
+
+
+# -- Request param types -----------------------------------------------------
+#
+# Parsed from request JSON bodies via `dacite.from_dict`. Missing required
+# fields surface as ParamError("<field> is required"); wrong types surface
+# via `dacite.WrongTypeError`.
+
+
+@dataclass
+class GetSmartFieldsParams:
+    noteType: str
+    deckId: Optional[int] = None
+
+
+@dataclass
+class ChatOptionsParams:
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    temperature: Optional[int] = None
+    markdownToHtml: Optional[bool] = None
+    webSearch: Optional[bool] = None
+
+
+@dataclass
+class TTSOptionsParams:
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    voice: Optional[str] = None
+    stripHtml: Optional[bool] = None
+
+
+@dataclass
+class ImageOptionsParams:
+    provider: Optional[str] = None
+    model: Optional[str] = None
+
+
+@dataclass
+class SmartFieldParams:
+    noteType: str
+    field: str
+    prompt: str
+    type: SmartFieldType = "chat"
+    deckId: Optional[int] = None
+    automatic: bool = True
+    useCustomModel: bool = False
+    chatOptions: Optional[ChatOptionsParams] = None
+    ttsOptions: Optional[TTSOptionsParams] = None
+    imageOptions: Optional[ImageOptionsParams] = None
+
+
+@dataclass
+class RemoveSmartFieldParams:
+    noteType: str
+    field: str
+    deckId: Optional[int] = None
+
+
+@dataclass
+class GenerateNoteParams:
+    noteId: int
+    deckId: Optional[int] = None
+    overwrite: bool = False
+    targetField: Optional[str] = None
+
+
+@dataclass
+class GenerateNotesParams:
+    noteIds: list[int]
+    deckId: Optional[int] = None
+    overwrite: bool = False
+
+
+@dataclass
+class UiEditSmartFieldParams:
+    noteType: str
+    field: str
+    deckId: Optional[int] = None
+
+
+@dataclass
+class UiNewSmartFieldParams:
+    fieldType: SmartFieldType
+    deckId: Optional[int] = None
+
+
+@dataclass
+class AuthCallbackBody:
+    jwt: str
+
+
+@dataclass
+class RpcRequest:
+    action: str
+    version: int
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+# -- Response envelope -------------------------------------------------------
+
+
+@dataclass
+class SmartFieldInfo:
+    prompt: str
+    extras: Optional[FieldExtras]
+
+
+@dataclass
+class GenerateNoteResult:
+    updated: bool
+    fields: dict[str, str]
+
+
+@dataclass
+class GenerateNotesResult:
+    updated: list[int]
+    failed: list[int]
+    skipped: list[int]
+
+
+def _envelope(result: Any = None, error: Optional[str] = None) -> web.Response:
+    return web.json_response({"result": result, "error": error})
+
+
+def _ok(result: Any = None) -> web.Response:
+    return _envelope(result=result)
+
+
+def _err(message: str) -> web.Response:
+    return _envelope(error=message)
+
+
+# -- CORS middleware ---------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CorsPolicy:
+    """Declarative CORS config for a single path.
+
+    `allowed_origins="*"` lets any origin through (used for the loopback ping
+    that exists only to surface the PNA consent prompt — it has no side effects
+    worth gating). A concrete set restricts to an allowlist and rejects
+    everything else with a plain 403.
+    """
+
+    allowed_origins: Union[frozenset[str], str]
+    allowed_methods: str
+
+    def is_allowed(self, origin: Optional[str]) -> bool:
+        if self.allowed_origins == "*":
+            return True
+        return origin is not None and origin in self.allowed_origins
+
+
+_PNA_HEADER = "Access-Control-Allow-Private-Network"
+
+
+def _cors_response_headers(policy: CorsPolicy, origin: Optional[str]) -> dict[str, str]:
+    echoed = origin if policy.allowed_origins != "*" else (origin or "*")
+    return {
+        "Access-Control-Allow-Origin": echoed or "*",
+        "Access-Control-Allow-Methods": f"{policy.allowed_methods}, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+        _PNA_HEADER: "true",
+        "Access-Control-Max-Age": "600",
+        "Vary": "Origin",
+    }
+
+
+@web.middleware
+async def cors_middleware(
+    request: web.Request,
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+) -> web.StreamResponse:
+    policy = CORS_POLICIES.get(request.path)
+
+    # No CORS on this path — handle normally (e.g. the `/` RPC endpoint).
+    if policy is None:
+        return await handler(request)
+
+    origin = request.headers.get("Origin")
+
+    # Preflight: short-circuit without invoking the handler.
+    if request.method == "OPTIONS":
+        if not policy.is_allowed(origin):
             return web.Response(status=403)
-        return web.Response(status=204, headers=self._cors_headers(origin))
+        return web.Response(status=204, headers=_cors_response_headers(policy, origin))
 
-    async def _handle_auth_callback(self, request: web.Request) -> web.Response:
-        origin = request.headers.get("Origin")
-        if origin not in ALLOWED_ORIGINS:
-            logger.warning(f"Rejected /auth/callback from origin: {origin}")
-            return web.json_response({"ok": False, "error": "forbidden"}, status=403)
-        headers = self._cors_headers(origin)
+    # Real request with a restricted origin: reject up front so the handler
+    # never sees the caller. Matches the previous per-endpoint gating.
+    if policy.allowed_origins != "*" and not policy.is_allowed(origin):
+        logger.warning(f"Rejected {request.path} from origin: {origin}")
+        return web.json_response({"ok": False, "error": "forbidden"}, status=403)
+
+    response = await handler(request)
+    response.headers.update(_cors_response_headers(policy, origin))
+    return response
+
+
+# Populated below once the policies' origin sets are known.
+CORS_POLICIES: dict[str, CorsPolicy] = {
+    "/auth/callback": CorsPolicy(ALLOWED_ORIGINS, "POST"),
+    "/subscription/refresh": CorsPolicy(ALLOWED_ORIGINS, "POST"),
+    "/ping": CorsPolicy("*", "GET"),
+}
+
+
+# -- Route registration ------------------------------------------------------
+
+
+def _register_routes(app: web.Application, processor: NoteProcessor) -> None:
+    # Browser-reachable endpoints. CORS middleware handles preflight; the
+    # OPTIONS routes below exist so aiohttp matches them rather than 405ing
+    # before middleware runs.
+    app.router.add_post("/auth/callback", handle_auth_callback)
+    app.router.add_options("/auth/callback", _options_stub)
+    app.router.add_post("/subscription/refresh", handle_subscription_refresh)
+    app.router.add_options("/subscription/refresh", _options_stub)
+    app.router.add_get("/ping", handle_loopback_ping)
+    app.router.add_options("/ping", _options_stub)
+
+    # Action-dispatched RPC endpoint.
+    app.router.add_post("/", make_rpc_handler(processor))
+
+
+async def _options_stub(_: web.Request) -> web.Response:
+    # Reached only if CORS middleware somehow misses — middleware always
+    # intercepts OPTIONS for mapped paths.
+    return web.Response(status=405)
+
+
+# -- Browser-facing handlers -------------------------------------------------
+
+
+async def handle_auth_callback(request: web.Request) -> web.Response:
+    try:
+        raw = await request.json()
+    except Exception:
+        return web.json_response({"ok": False, "error": "invalid_json"}, status=400)
+
+    try:
+        body = parse_params(AuthCallbackBody, raw)
+    except ParamError:
+        return web.json_response({"ok": False, "error": "missing_jwt"}, status=400)
+
+    if not body.jwt:
+        return web.json_response({"ok": False, "error": "missing_jwt"}, status=400)
+
+    def write_token() -> None:
+        config.auth_token = body.jwt
+        if sentry:
+            sentry.set_user()
+        app_state.update_subscription_state()
+
+    if mw:
+        mw.taskman.run_on_main(write_token)
+    return web.json_response({"ok": True})
+
+
+async def handle_subscription_refresh(_: web.Request) -> web.Response:
+    if mw:
+        mw.taskman.run_on_main(app_state.update_subscription_state)
+    return web.json_response({"ok": True})
+
+
+async def handle_loopback_ping(_: web.Request) -> web.Response:
+    # Browser-reachable no-op used to surface the PNA consent prompt on a
+    # user gesture before the real JWT post. Intentionally unguarded —
+    # no sensitive response, no side effect.
+    return web.json_response({"ok": True})
+
+
+# -- RPC dispatch ------------------------------------------------------------
+
+
+def make_rpc_handler(
+    processor: NoteProcessor,
+) -> Callable[[web.Request], Awaitable[web.Response]]:
+    """Build the `POST /` handler. Accepts `{action, version, params}` and
+    dispatches to a registered action handler."""
+
+    async def rpc_handler(request: web.Request) -> web.Response:
         try:
-            body = await request.json()
+            raw = await request.json()
         except Exception:
-            return web.json_response(
-                {"ok": False, "error": "invalid_json"}, status=400, headers=headers
-            )
-        jwt = body.get("jwt")
-        if not isinstance(jwt, str) or not jwt:
-            return web.json_response(
-                {"ok": False, "error": "missing_jwt"}, status=400, headers=headers
-            )
-
-        def write_token() -> None:
-            config.auth_token = jwt
-            if sentry:
-                sentry.set_user()
-            app_state.update_subscription_state()
-
-        if mw:
-            mw.taskman.run_on_main(write_token)
-        return web.json_response({"ok": True}, headers=headers)
-
-    async def _handle_subscription_refresh(self, request: web.Request) -> web.Response:
-        origin = request.headers.get("Origin")
-        if origin not in ALLOWED_ORIGINS:
-            return web.json_response({"ok": False, "error": "forbidden"}, status=403)
-        if mw:
-            mw.taskman.run_on_main(app_state.update_subscription_state)
-        return web.json_response({"ok": True}, headers=self._cors_headers(origin))
-
-    async def _handle_loopback_ping(self, request: web.Request) -> web.Response:
-        # Browser-reachable no-op used to surface the PNA consent prompt on a
-        # user gesture before the real JWT post. No origin allowlist — the
-        # response carries no sensitive info and no side effect.
-        origin = request.headers.get("Origin", "*")
-        return web.json_response({"ok": True}, headers=self._cors_headers(origin))
-
-    async def _handle_ping_preflight(self, request: web.Request) -> web.Response:
-        origin = request.headers.get("Origin", "*")
-        return web.Response(status=204, headers=self._cors_headers(origin))
-
-    async def _handle_request(self, request: web.Request) -> web.Response:
-        try:
-            body = await request.json()
-        except Exception:
-            return web.json_response(_err("Invalid JSON"))
-
-        action = body.get("action")
-        version = body.get("version")
-        params = body.get("params", {})
-
-        if version != API_VERSION:
-            return web.json_response(
-                _err(f"Unsupported version: {version}, expected {API_VERSION}")
-            )
-
-        if action not in self._actions:
-            return web.json_response(_err(f"Unknown action: {action}"))
+            return _err("Invalid JSON")
 
         try:
-            result = await self._actions[action](params)
-            return web.json_response(result)
+            rpc = parse_params(RpcRequest, raw)
+        except ParamError as e:
+            return _err(str(e))
+
+        if rpc.version != API_VERSION:
+            return _err(f"Unsupported version: {rpc.version}, expected {API_VERSION}")
+
+        handler = ACTIONS.get(rpc.action)
+        if handler is None:
+            return _err(f"Unknown action: {rpc.action}")
+
+        try:
+            return await handler(processor, rpc.params)
+        except ParamError as e:
+            return _err(str(e))
         except Exception as e:
             logger.error(
-                f"Local server error handling {action}: "
+                f"Local server error handling {rpc.action}: "
                 f"{''.join(traceback.format_exception(type(e), e, e.__traceback__))}"
             )
-            return web.json_response(_err(str(e)))
+            return _err(str(e))
 
-    async def _handle_ping(self, params: dict[str, Any]) -> ApiResponse:
-        return _ok("pong")
+    return rpc_handler
 
-    async def _handle_get_smart_fields(
-        self, params: GetSmartFieldsParams
-    ) -> ApiResponse:
-        note_type = params.get("noteType")
-        if not note_type:
-            return _err("noteType is required")
 
-        deck_id = _get_deck_id(params)
+# -- Action handlers ---------------------------------------------------------
 
-        prompts = get_prompts_for_note(
-            note_type, deck_id, fallback_to_global_deck=(deck_id == GLOBAL_DECK_ID)
+
+async def action_ping(_: NoteProcessor, __: dict[str, Any]) -> web.Response:
+    return _ok("pong")
+
+
+async def action_get_smart_fields(
+    _: NoteProcessor, raw: dict[str, Any]
+) -> web.Response:
+    params = parse_params(GetSmartFieldsParams, raw)
+    deck_id = _resolve_deck_id(params.deckId)
+
+    prompts = get_prompts_for_note(
+        params.noteType,
+        deck_id,
+        fallback_to_global_deck=(deck_id == GLOBAL_DECK_ID),
+    )
+    if not prompts:
+        return _ok({})
+
+    result: dict[str, dict[str, Any]] = {}
+    for field_name, prompt in prompts.items():
+        extras = get_extras(
+            note_type=params.noteType, field=field_name, deck_id=deck_id
         )
-        if not prompts:
-            return _ok({})
+        result[field_name] = {"prompt": prompt, "extras": extras}
 
-        result: dict[str, SmartFieldInfo] = {}
-        for field, prompt in prompts.items():
-            extras = get_extras(
-                note_type=note_type,
-                field=field,
-                deck_id=deck_id,
-            )
-            result[field] = {"prompt": prompt, "extras": extras}
+    return _ok(result)
 
-        return _ok(result)
 
-    async def _handle_add_smart_field(self, params: SmartFieldParams) -> ApiResponse:
-        note_type = params.get("noteType")
-        field = params.get("field")
-        prompt = params.get("prompt")
-        field_type: SmartFieldType = params.get("type", "chat")
+async def action_add_smart_field(_: NoteProcessor, raw: dict[str, Any]) -> web.Response:
+    params = parse_params(SmartFieldParams, raw)
+    deck_id = _resolve_deck_id(params.deckId)
 
-        if not note_type or not field or not prompt:
-            return _err("noteType, field, and prompt are required")
-
-        deck_id = _get_deck_id(params)
-
-        existing = get_prompts_for_note(
-            note_type, deck_id, fallback_to_global_deck=False
-        )
-        if existing and field in existing:
-            return _err(
-                f"Field '{field}' already exists for noteType '{note_type}' "
-                f"and deckId {deck_id}"
-            )
-
-        return await self._save_smart_field(
-            params, note_type, field, prompt, field_type, deck_id
+    existing = get_prompts_for_note(
+        params.noteType, deck_id, fallback_to_global_deck=False
+    )
+    if existing and params.field in existing:
+        return _err(
+            f"Field '{params.field}' already exists for noteType "
+            f"'{params.noteType}' and deckId {deck_id}"
         )
 
-    async def _handle_update_smart_field(self, params: SmartFieldParams) -> ApiResponse:
-        note_type = params.get("noteType")
-        field = params.get("field")
-        prompt = params.get("prompt")
-        field_type: SmartFieldType = params.get("type", "chat")
+    return _save_smart_field(params, deck_id)
 
-        if not note_type or not field or not prompt:
-            return _err("noteType, field, and prompt are required")
 
-        deck_id = _get_deck_id(params)
+async def action_update_smart_field(
+    _: NoteProcessor, raw: dict[str, Any]
+) -> web.Response:
+    params = parse_params(SmartFieldParams, raw)
+    deck_id = _resolve_deck_id(params.deckId)
 
-        existing = get_prompts_for_note(
-            note_type, deck_id, fallback_to_global_deck=False
-        )
-        if not existing or field not in existing:
-            return _err(
-                f"Field '{field}' does not exist for noteType '{note_type}' "
-                f"and deckId {deck_id}"
-            )
-
-        return await self._save_smart_field(
-            params, note_type, field, prompt, field_type, deck_id
+    existing = get_prompts_for_note(
+        params.noteType, deck_id, fallback_to_global_deck=False
+    )
+    if not existing or params.field not in existing:
+        return _err(
+            f"Field '{params.field}' does not exist for noteType "
+            f"'{params.noteType}' and deckId {deck_id}"
         )
 
-    async def _save_smart_field(
-        self,
-        params: SmartFieldParams,
-        note_type: str,
-        field: str,
-        prompt: str,
-        field_type: SmartFieldType,
-        deck_id: DeckId,
-    ) -> ApiResponse:
-        is_automatic = params.get("automatic", True)
-        use_custom_model = params.get("useCustomModel", False)
+    return _save_smart_field(params, deck_id)
 
-        chat_options: OverridableChatOptionsDict = {
-            "chat_provider": params.get("chatOptions", {}).get("provider"),
-            "chat_model": params.get("chatOptions", {}).get("model"),
-            "chat_temperature": params.get("chatOptions", {}).get("temperature"),
-            "chat_markdown_to_html": params.get("chatOptions", {}).get(
-                "markdownToHtml"
-            ),
-            "chat_web_search": params.get("chatOptions", {}).get("webSearch"),
-        }
 
-        tts_options: OverrideableTTSOptionsDict = {
-            "tts_provider": params.get("ttsOptions", {}).get("provider"),
-            "tts_model": params.get("ttsOptions", {}).get("model"),
-            "tts_voice": params.get("ttsOptions", {}).get("voice"),
-            "tts_strip_html": params.get("ttsOptions", {}).get("stripHtml"),
-        }
+async def action_remove_smart_field(
+    _: NoteProcessor, raw: dict[str, Any]
+) -> web.Response:
+    params = parse_params(RemoveSmartFieldParams, raw)
+    deck_id = _resolve_deck_id(params.deckId)
 
-        image_options: OverridableImageOptionsDict = {
-            "image_provider": params.get("imageOptions", {}).get("provider"),
-            "image_model": params.get("imageOptions", {}).get("model"),
-        }
-
-        def do_save() -> None:
-            new_map = add_or_update_prompts(
-                prompts_map=config.prompts_map,
-                note_type=note_type,
-                deck_id=deck_id,
-                field=field,
-                prompt=prompt,
-                is_automatic=is_automatic,
-                is_custom_model=use_custom_model,
-                type=field_type,
-                tts_options=tts_options,
-                chat_options=chat_options,
-                image_options=image_options,
-            )
-            config.prompts_map = new_map
-
-        _run_on_main_sync(do_save)
-        return _ok(True)
-
-    async def _handle_remove_smart_field(
-        self, params: RemoveSmartFieldParams
-    ) -> ApiResponse:
-        note_type = params.get("noteType")
-        field = params.get("field")
-
-        if not note_type or not field:
-            return _err("noteType and field are required")
-
-        deck_id = _get_deck_id(params)
-
-        def do_remove() -> None:
-            new_map = remove_prompt(
-                prompts_map=config.prompts_map,
-                note_type=note_type,
-                deck_id=deck_id,
-                field=field,
-            )
-            config.prompts_map = new_map
-
-        _run_on_main_sync(do_remove)
-        return _ok(True)
-
-    async def _handle_generate_note(self, params: GenerateNoteParams) -> ApiResponse:
-        note_id_raw = params.get("noteId")
-        if note_id_raw is None:
-            return _err("noteId is required")
-
-        if not mw or not mw.col:
-            return _err("Anki collection not available")
-
-        note_id = cast(NoteId, int(note_id_raw))
-        note = mw.col.get_note(note_id)
-
-        overwrite = params.get("overwrite", False)
-        target_field = params.get("targetField")
-
-        deck_id: Optional[DeckId] = None
-        raw_deck = params.get("deckId")
-        if raw_deck is not None:
-            deck_id = cast(DeckId, int(raw_deck))
-        else:
-            cards = note.cards()
-            if cards:
-                deck_id = cards[0].did
-
-        if deck_id is None:
-            return _err("Could not determine deckId for note")
-
-        fields_before = {f: note[f] for f in note.keys()}  # noqa: SIM118
-
-        updated = await self._processor._process_note(  # type: ignore
-            note,
+    def do_remove() -> None:
+        config.prompts_map = remove_prompt(
+            prompts_map=config.prompts_map,
+            note_type=params.noteType,
             deck_id=deck_id,
-            overwrite_fields=overwrite,
-            target_field=target_field,
+            field=params.field,
         )
 
-        if updated:
-            _run_on_main_sync(
-                lambda: mw.col.update_note(note) if mw and mw.col else None
-            )
+    _run_on_main_sync(do_remove)
+    return _ok(True)
 
-        fields_after = {f: note[f] for f in note.keys()}  # noqa: SIM118
-        changed_fields = {
-            f: fields_after[f]
-            for f in fields_after
-            if fields_after[f] != fields_before.get(f)
-        }
 
-        result: GenerateNoteResult = {"updated": updated, "fields": changed_fields}
-        return _ok(result)
+async def action_generate_note(
+    processor: NoteProcessor, raw: dict[str, Any]
+) -> web.Response:
+    params = parse_params(GenerateNoteParams, raw)
 
-    async def _handle_generate_notes(self, params: GenerateNotesParams) -> ApiResponse:
-        note_ids_raw = params.get("noteIds")
-        if not note_ids_raw:
-            return _err("noteIds is required")
+    if not mw or not mw.col:
+        return _err("Anki collection not available")
 
-        if not mw or not mw.col:
-            return _err("Anki collection not available")
+    note_id = cast(NoteId, params.noteId)
+    note = mw.col.get_note(note_id)
 
-        overwrite = params.get("overwrite", False)
+    deck_id: Optional[DeckId] = None
+    if params.deckId is not None:
+        deck_id = cast(DeckId, params.deckId)
+    else:
+        cards = note.cards()
+        if cards:
+            deck_id = cards[0].did
 
-        note_ids = [cast(NoteId, int(nid)) for nid in note_ids_raw]
+    if deck_id is None:
+        return _err("Could not determine deckId for note")
 
-        did_map: dict[NoteId, DeckId] = {}
-        raw_deck = params.get("deckId")
-        for nid in note_ids:
-            if raw_deck is not None:
-                did_map[nid] = cast(DeckId, int(raw_deck))
-            else:
-                note = mw.col.get_note(nid)
-                cards = note.cards()
-                if cards:
-                    did_map[nid] = cards[0].did
+    fields_before = {f: note[f] for f in note.keys()}  # noqa: SIM118
 
-        (
-            updated_notes,
-            failed_notes,
-            skipped_notes,
-        ) = await self._processor._process_notes_batch(  # type: ignore
-            note_ids,
-            overwrite_fields=overwrite,
-            did_map=did_map,
+    updated = await processor._process_note(  # type: ignore[attr-defined]
+        note,
+        deck_id=deck_id,
+        overwrite_fields=params.overwrite,
+        target_field=params.targetField,
+    )
+
+    if updated:
+        _run_on_main_sync(lambda: mw.col.update_note(note) if mw and mw.col else None)
+
+    fields_after = {f: note[f] for f in note.keys()}  # noqa: SIM118
+    changed_fields = {
+        f: fields_after[f]
+        for f in fields_after
+        if fields_after[f] != fields_before.get(f)
+    }
+
+    return _ok({"updated": updated, "fields": changed_fields})
+
+
+async def action_generate_notes(
+    processor: NoteProcessor, raw: dict[str, Any]
+) -> web.Response:
+    params = parse_params(GenerateNotesParams, raw)
+
+    if not params.noteIds:
+        return _err("noteIds is required")
+
+    if not mw or not mw.col:
+        return _err("Anki collection not available")
+
+    note_ids = [cast(NoteId, nid) for nid in params.noteIds]
+
+    did_map: dict[NoteId, DeckId] = {}
+    for nid in note_ids:
+        if params.deckId is not None:
+            did_map[nid] = cast(DeckId, params.deckId)
+        else:
+            cards = mw.col.get_note(nid).cards()
+            if cards:
+                did_map[nid] = cards[0].did
+
+    (
+        updated_notes,
+        failed_notes,
+        skipped_notes,
+    ) = await processor._process_notes_batch(  # type: ignore[attr-defined]
+        note_ids,
+        overwrite_fields=params.overwrite,
+        did_map=did_map,
+    )
+
+    if updated_notes:
+        _run_on_main_sync(
+            lambda: mw.col.update_notes(updated_notes) if mw and mw.col else None
         )
 
-        if updated_notes:
-            _run_on_main_sync(
-                lambda: mw.col.update_notes(updated_notes) if mw and mw.col else None
-            )
-
-        result: GenerateNotesResult = {
+    return _ok(
+        {
             "updated": [n.id for n in updated_notes],
             "failed": [n.id for n in failed_notes],
             "skipped": [n.id for n in skipped_notes],
         }
-        return _ok(result)
+    )
 
-    async def _handle_ui_edit_smart_field(self, params: dict[str, Any]) -> ApiResponse:
-        note_type = params.get("noteType")
-        field = params.get("field")
 
-        if not note_type or not field:
-            return _err("noteType and field are required")
+async def action_ui_edit_smart_field(
+    processor: NoteProcessor, raw: dict[str, Any]
+) -> web.Response:
+    params = parse_params(UiEditSmartFieldParams, raw)
+    deck_id = _resolve_deck_id(params.deckId)
 
-        deck_id = _get_deck_id(params)
+    extras = get_extras(note_type=params.noteType, field=params.field, deck_id=deck_id)
+    if not extras:
+        return _err(f"No smart field '{params.field}' for noteType '{params.noteType}'")
 
-        extras = get_extras(note_type=note_type, field=field, deck_id=deck_id)
-        if not extras:
-            return _err(f"No smart field '{field}' for noteType '{note_type}'")
+    prompts = get_prompts_for_note(
+        note_type=params.noteType,
+        to_lower=True,
+        deck_id=deck_id,
+        fallback_to_global_deck=False,
+    )
+    all_fields = get_fields(params.noteType)
+    if not prompts or params.field not in all_fields:
+        return _err("Note type does not exist or field not in note type")
 
-        prompts = get_prompts_for_note(
-            note_type=note_type,
-            to_lower=True,
+    field_type = extras["type"]
+
+    def open_dialog() -> bool:
+        def on_accept(new_map: Any) -> None:
+            config.prompts_map = new_map
+
+        dialog = PromptDialog(
+            config.prompts_map,
+            processor,
+            on_accept,
+            card_type=params.noteType,
             deck_id=deck_id,
-            fallback_to_global_deck=False,
+            field=params.field,
+            field_type=field_type,
+            prompt=prompts[params.field.lower()],
+        )
+        return dialog.exec() == QDialog.DialogCode.Accepted
+
+    return _ok(_run_on_main_sync(open_dialog))
+
+
+async def action_ui_new_smart_field(
+    processor: NoteProcessor, raw: dict[str, Any]
+) -> web.Response:
+    params = parse_params(UiNewSmartFieldParams, raw)
+    deck_id = _resolve_deck_id(params.deckId)
+
+    def open_dialog() -> bool:
+        def on_accept(new_map: Any) -> None:
+            config.prompts_map = new_map
+
+        dialog = PromptDialog(
+            config.prompts_map,
+            processor,
+            on_accept,
+            field_type=params.fieldType,
+            deck_id=deck_id,
+        )
+        return dialog.exec() == QDialog.DialogCode.Accepted
+
+    return _ok(_run_on_main_sync(open_dialog))
+
+
+# -- Action registry ---------------------------------------------------------
+
+
+ActionHandler = Callable[[NoteProcessor, dict[str, Any]], Awaitable[web.Response]]
+
+ACTIONS: dict[str, ActionHandler] = {
+    "ping": action_ping,
+    "getSmartFields": action_get_smart_fields,
+    "addSmartField": action_add_smart_field,
+    "updateSmartField": action_update_smart_field,
+    "removeSmartField": action_remove_smart_field,
+    "generateNote": action_generate_note,
+    "generateNotes": action_generate_notes,
+    "uiEditSmartField": action_ui_edit_smart_field,
+    "uiNewSmartField": action_ui_new_smart_field,
+}
+
+
+# -- Helpers -----------------------------------------------------------------
+
+
+T = TypeVar("T")
+
+
+class ParamError(Exception):
+    """Raised when request params fail dacite validation. The message is
+    safe to surface to callers — it only names the offending field."""
+
+
+def parse_params(cls: type[T], raw: Any) -> T:
+    if not isinstance(raw, dict):
+        raise ParamError("Request body must be a JSON object")
+    try:
+        return dacite.from_dict(data_class=cls, data=raw)
+    except dacite.MissingValueError as e:
+        raise ParamError(f"{e.field_path} is required") from e
+    except dacite.WrongTypeError as e:
+        raise ParamError(f"Invalid type for field '{e.field_path}'") from e
+    except dacite.DaciteError as e:
+        raise ParamError(str(e)) from e
+
+
+def _resolve_deck_id(raw: Optional[int]) -> DeckId:
+    if raw is None:
+        return GLOBAL_DECK_ID
+    return cast(DeckId, int(raw))
+
+
+def _run_on_main_sync(fn: Callable[[], Any]) -> Any:
+    if not mw:
+        raise RuntimeError("mw not available")
+    future: concurrent.futures.Future[Any] = concurrent.futures.Future()
+
+    def work() -> None:
+        try:
+            future.set_result(fn())
+        except Exception as e:
+            future.set_exception(e)
+
+    mw.taskman.run_on_main(work)
+    return future.result(timeout=30)
+
+
+def _save_smart_field(params: SmartFieldParams, deck_id: DeckId) -> web.Response:
+    # Cast incoming strings to the strongly-typed Literal unions the config
+    # layer expects. We intentionally accept any string at the boundary — see
+    # the note above the dataclasses for why.
+    chat = params.chatOptions
+    tts = params.ttsOptions
+    image = params.imageOptions
+
+    chat_options: OverridableChatOptionsDict = {
+        "chat_provider": cast(Any, chat.provider) if chat else None,
+        "chat_model": cast(Any, chat.model) if chat else None,
+        "chat_temperature": chat.temperature if chat else None,
+        "chat_markdown_to_html": chat.markdownToHtml if chat else None,
+        "chat_web_search": chat.webSearch if chat else None,
+    }
+
+    tts_options: OverrideableTTSOptionsDict = {
+        "tts_provider": cast(Any, tts.provider) if tts else None,
+        "tts_model": cast(Any, tts.model) if tts else None,
+        "tts_voice": tts.voice if tts else None,
+        "tts_strip_html": tts.stripHtml if tts else None,
+    }
+
+    image_options: OverridableImageOptionsDict = {
+        "image_provider": cast(Any, image.provider) if image else None,
+        "image_model": cast(Any, image.model) if image else None,
+    }
+
+    def do_save() -> None:
+        config.prompts_map = add_or_update_prompts(
+            prompts_map=config.prompts_map,
+            note_type=params.noteType,
+            deck_id=deck_id,
+            field=params.field,
+            prompt=params.prompt,
+            is_automatic=params.automatic,
+            is_custom_model=params.useCustomModel,
+            type=params.type,
+            tts_options=tts_options,
+            chat_options=chat_options,
+            image_options=image_options,
         )
 
-        all_fields = get_fields(note_type)
-        if not prompts or field not in all_fields:
-            return _err("Note type does not exist or field not in note type")
-
-        field_type = extras["type"]
-
-        def open_dialog() -> bool:
-            def on_accept(new_map: Any) -> None:
-                config.prompts_map = new_map
-
-            dialog = PromptDialog(
-                config.prompts_map,
-                self._processor,
-                on_accept,
-                card_type=note_type,
-                deck_id=deck_id,
-                field=field,
-                field_type=field_type,
-                prompt=prompts[field.lower()],
-            )
-            return dialog.exec() == QDialog.DialogCode.Accepted
-
-        accepted = _run_on_main_sync(open_dialog)
-        return _ok(accepted)
-
-    async def _handle_ui_new_smart_field(self, params: dict[str, Any]) -> ApiResponse:
-        field_type: Optional[SmartFieldType] = params.get("fieldType")
-
-        if not field_type or field_type not in ("chat", "tts", "image"):
-            return _err("fieldType is required (chat, tts, or image)")
-
-        deck_id = _get_deck_id(params)
-
-        def open_dialog() -> bool:
-            def on_accept(new_map: Any) -> None:
-                config.prompts_map = new_map
-
-            dialog = PromptDialog(
-                config.prompts_map,
-                self._processor,
-                on_accept,
-                field_type=field_type,
-                deck_id=deck_id,
-            )
-            return dialog.exec() == QDialog.DialogCode.Accepted
-
-        accepted = _run_on_main_sync(open_dialog)
-        return _ok(accepted)
+    _run_on_main_sync(do_save)
+    return _ok(True)

--- a/src/local_server.py
+++ b/src/local_server.py
@@ -28,7 +28,7 @@ import threading
 import traceback
 from collections.abc import Awaitable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Optional, TypeVar, cast
 
 import dacite
 from aiohttp import web
@@ -39,7 +39,7 @@ from aqt.qt import QDialog
 
 from .app_state import app_state
 from .config import config
-from .constants import GLOBAL_DECK_ID, SITE_URL_DEV
+from .constants import GLOBAL_DECK_ID
 from .logger import logger
 from .models import (
     FieldExtras,
@@ -122,14 +122,6 @@ def build_app(processor: NoteProcessor) -> web.Application:
 LOCAL_SERVER_PORT = 8766
 LOCAL_SERVER_HOST = "127.0.0.1"
 API_VERSION = 1
-
-ALLOWED_ORIGINS: frozenset[str] = frozenset(
-    {
-        "https://smart-notes.xyz",
-        "https://www.smart-notes.xyz",
-        SITE_URL_DEV,
-    }
-)
 
 
 # -- Request param types -----------------------------------------------------
@@ -264,38 +256,25 @@ def _err(message: str) -> web.Response:
 
 
 # -- CORS middleware ---------------------------------------------------------
+#
+# The browser-facing paths (`/auth/callback`, `/subscription/refresh`, `/ping`)
+# need CORS headers or the browser rejects the response. We do not enforce an
+# origin allowlist: a hostile page could at worst overwrite the user's JWT
+# with one of its own, which just redirects API costs to the attacker's
+# account. Not a threat model worth complicating the code for.
 
 
-@dataclass(frozen=True)
-class CorsPolicy:
-    """Declarative CORS config for a single path.
-
-    `allowed_origins="*"` lets any origin through (used for the loopback ping
-    that exists only to surface the PNA consent prompt — it has no side effects
-    worth gating). A concrete set restricts to an allowlist and rejects
-    everything else with a plain 403.
-    """
-
-    allowed_origins: Union[frozenset[str], str]
-    allowed_methods: str
-
-    def is_allowed(self, origin: Optional[str]) -> bool:
-        if self.allowed_origins == "*":
-            return True
-        return origin is not None and origin in self.allowed_origins
+CORS_PATHS: frozenset[str] = frozenset(
+    {"/auth/callback", "/subscription/refresh", "/ping"}
+)
 
 
-_PNA_HEADER = "Access-Control-Allow-Private-Network"
-
-
-def _cors_response_headers(policy: CorsPolicy, origin: Optional[str]) -> dict[str, str]:
-    echoed = origin if policy.allowed_origins != "*" else (origin or "*")
+def cors_headers(origin: Optional[str]) -> dict[str, str]:
     return {
-        "Access-Control-Allow-Origin": echoed or "*",
-        "Access-Control-Allow-Methods": f"{policy.allowed_methods}, OPTIONS",
+        "Access-Control-Allow-Origin": origin or "*",
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type",
-        _PNA_HEADER: "true",
-        "Access-Control-Max-Age": "600",
+        "Access-Control-Allow-Private-Network": "true",
         "Vary": "Origin",
     }
 
@@ -305,37 +284,16 @@ async def cors_middleware(
     request: web.Request,
     handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
 ) -> web.StreamResponse:
-    policy = CORS_POLICIES.get(request.path)
-
-    # No CORS on this path — handle normally (e.g. the `/` RPC endpoint).
-    if policy is None:
+    if request.path not in CORS_PATHS:
         return await handler(request)
 
     origin = request.headers.get("Origin")
-
-    # Preflight: short-circuit without invoking the handler.
     if request.method == "OPTIONS":
-        if not policy.is_allowed(origin):
-            return web.Response(status=403)
-        return web.Response(status=204, headers=_cors_response_headers(policy, origin))
-
-    # Real request with a restricted origin: reject up front so the handler
-    # never sees the caller. Matches the previous per-endpoint gating.
-    if policy.allowed_origins != "*" and not policy.is_allowed(origin):
-        logger.warning(f"Rejected {request.path} from origin: {origin}")
-        return web.json_response({"ok": False, "error": "forbidden"}, status=403)
+        return web.Response(status=204, headers=cors_headers(origin))
 
     response = await handler(request)
-    response.headers.update(_cors_response_headers(policy, origin))
+    response.headers.update(cors_headers(origin))
     return response
-
-
-# Populated below once the policies' origin sets are known.
-CORS_POLICIES: dict[str, CorsPolicy] = {
-    "/auth/callback": CorsPolicy(ALLOWED_ORIGINS, "POST"),
-    "/subscription/refresh": CorsPolicy(ALLOWED_ORIGINS, "POST"),
-    "/ping": CorsPolicy("*", "GET"),
-}
 
 
 # -- Route registration ------------------------------------------------------

--- a/tests/test_local_server.py
+++ b/tests/test_local_server.py
@@ -396,26 +396,19 @@ async def test_auth_callback_happy_path(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_auth_callback_rejects_bad_origin(monkeypatch):
-    _patch_auth_callback_deps(monkeypatch)
+async def test_auth_callback_accepts_any_origin(monkeypatch):
+    # No allowlist — the add-on trusts whoever can reach localhost.
+    written = _patch_auth_callback_deps(monkeypatch)
 
     async with TestClient(TestServer(_make_app())) as client:
         resp = await client.post(
             "/auth/callback",
             json={"jwt": "abc.def.ghi"},
-            headers={"Origin": "https://evil.com"},
+            headers={"Origin": "https://anywhere.example"},
         )
-        assert resp.status == 403
-        assert "Access-Control-Allow-Origin" not in resp.headers
-
-
-@pytest.mark.asyncio
-async def test_auth_callback_rejects_missing_origin(monkeypatch):
-    _patch_auth_callback_deps(monkeypatch)
-
-    async with TestClient(TestServer(_make_app())) as client:
-        resp = await client.post("/auth/callback", json={"jwt": "abc.def.ghi"})
-        assert resp.status == 403
+        assert resp.status == 200
+        assert resp.headers["Access-Control-Allow-Origin"] == "https://anywhere.example"
+        assert written["jwt"] == "abc.def.ghi"
 
 
 @pytest.mark.asyncio
@@ -462,7 +455,7 @@ async def test_auth_callback_non_string_jwt(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_auth_preflight_allowed_origin():
+async def test_auth_preflight_returns_cors_headers():
     async with TestClient(TestServer(_make_app())) as client:
         resp = await client.options(
             "/auth/callback", headers={"Origin": ALLOWED_ORIGIN}
@@ -471,15 +464,6 @@ async def test_auth_preflight_allowed_origin():
         assert resp.headers["Access-Control-Allow-Origin"] == ALLOWED_ORIGIN
         assert resp.headers["Access-Control-Allow-Private-Network"] == "true"
         assert "POST" in resp.headers["Access-Control-Allow-Methods"]
-
-
-@pytest.mark.asyncio
-async def test_auth_preflight_rejects_bad_origin():
-    async with TestClient(TestServer(_make_app())) as client:
-        resp = await client.options(
-            "/auth/callback", headers={"Origin": "https://evil.com"}
-        )
-        assert resp.status == 403
 
 
 # -- /subscription/refresh ---------------------------------------------------
@@ -511,18 +495,6 @@ async def test_subscription_refresh_happy_path(monkeypatch):
         assert called["n"] == 1
 
 
-@pytest.mark.asyncio
-async def test_subscription_refresh_rejects_bad_origin():
-    async with TestClient(TestServer(_make_app())) as client:
-        resp = await client.post(
-            "/subscription/refresh",
-            json={},
-            headers={"Origin": "https://evil.com"},
-        )
-        assert resp.status == 403
-        assert "Access-Control-Allow-Origin" not in resp.headers
-
-
 # -- /ping -------------------------------------------------------------------
 
 
@@ -536,13 +508,12 @@ async def test_loopback_ping_returns_ok():
 
 
 @pytest.mark.asyncio
-async def test_loopback_ping_open_to_any_origin():
-    # Intentionally no origin allowlist — the response is a harmless no-op
-    # and the PNA consent prompt is not worth protecting here.
+async def test_loopback_ping_echoes_any_origin():
     async with TestClient(TestServer(_make_app())) as client:
-        resp = await client.get("/ping", headers={"Origin": "https://evil.com"})
+        resp = await client.get("/ping", headers={"Origin": "https://anywhere.example"})
         assert resp.status == 200
         assert (await resp.json()) == {"ok": True}
+        assert resp.headers["Access-Control-Allow-Origin"] == "https://anywhere.example"
 
 
 @pytest.mark.asyncio

--- a/tests/test_local_server.py
+++ b/tests/test_local_server.py
@@ -23,7 +23,6 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 
@@ -35,22 +34,10 @@ def _err(message: str) -> dict[str, Any]:
     return {"result": None, "error": message}
 
 
-def _make_server():
-    from src.local_server import LocalServer
-
-    processor = MagicMock()
-    return LocalServer(processor)
-
-
 def _make_app():
-    server = _make_server()
-    app = web.Application()
-    app.router.add_post("/", server._handle_request)
-    app.router.add_post("/auth/callback", server._handle_auth_callback)
-    app.router.add_options("/auth/callback", server._handle_auth_preflight)
-    app.router.add_get("/ping", server._handle_loopback_ping)
-    app.router.add_options("/ping", server._handle_ping_preflight)
-    return app
+    from src.local_server import build_app
+
+    return build_app(MagicMock())
 
 
 ALLOWED_ORIGIN = "https://smart-notes.xyz"
@@ -66,6 +53,9 @@ def make_request(action: str, params: dict[str, Any] | None = None) -> dict[str,
 async def _post(client: TestClient, data: dict[str, Any]) -> dict[str, Any]:
     resp = await client.post("/", json=data)
     return await resp.json()
+
+
+# -- RPC dispatch ------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -97,6 +87,9 @@ async def test_unknown_action():
     async with TestClient(TestServer(_make_app())) as client:
         data = await _post(client, make_request("nonExistent"))
         assert data == _err("Unknown action: nonExistent")
+
+
+# -- getSmartFields ----------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -147,11 +140,25 @@ async def test_get_smart_fields_empty(monkeypatch):
         assert data == _ok({})
 
 
+# -- addSmartField / updateSmartField ----------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_add_smart_field_missing_params():
+async def test_add_smart_field_missing_field():
     async with TestClient(TestServer(_make_app())) as client:
         data = await _post(client, make_request("addSmartField", {"noteType": "Basic"}))
-        assert data["error"] == "noteType, field, and prompt are required"
+        # dacite reports the first missing required field.
+        assert data["error"] == "field is required"
+
+
+@pytest.mark.asyncio
+async def test_add_smart_field_missing_prompt():
+    async with TestClient(TestServer(_make_app())) as client:
+        data = await _post(
+            client,
+            make_request("addSmartField", {"noteType": "Basic", "field": "Back"}),
+        )
+        assert data["error"] == "prompt is required"
 
 
 @pytest.mark.asyncio
@@ -268,13 +275,16 @@ async def test_update_smart_field_success(monkeypatch):
         assert data == _ok(True)
 
 
+# -- removeSmartField --------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_remove_smart_field_missing_params():
+async def test_remove_smart_field_missing_field():
     async with TestClient(TestServer(_make_app())) as client:
         data = await _post(
             client, make_request("removeSmartField", {"noteType": "Basic"})
         )
-        assert data["error"] == "noteType and field are required"
+        assert data["error"] == "field is required"
 
 
 @pytest.mark.asyncio
@@ -301,6 +311,9 @@ async def test_remove_smart_field_success(monkeypatch):
             ),
         )
         assert data == _ok(True)
+
+
+# -- generateNote / generateNotes --------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -339,11 +352,11 @@ async def test_generate_notes_no_collection(monkeypatch):
         assert data["error"] == "Anki collection not available"
 
 
-# -- /auth/callback --
+# -- /auth/callback ----------------------------------------------------------
 
 
 def _patch_auth_callback_deps(monkeypatch):
-    """Replace config/sentry/app_state so _handle_auth_callback is pure."""
+    """Replace config/sentry/app_state so handle_auth_callback is pure."""
     import src.local_server
 
     written: dict[str, Any] = {"jwt": None}
@@ -469,7 +482,48 @@ async def test_auth_preflight_rejects_bad_origin():
         assert resp.status == 403
 
 
-# -- /ping --
+# -- /subscription/refresh ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscription_refresh_happy_path(monkeypatch):
+    import src.local_server
+
+    called = {"n": 0}
+
+    def fake_run_on_main(fn):
+        called["n"] += 1
+
+    fake_mw = MagicMock()
+    fake_mw.taskman.run_on_main = fake_run_on_main
+    monkeypatch.setattr(src.local_server, "mw", fake_mw)
+    monkeypatch.setattr(src.local_server, "app_state", MagicMock())
+
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(
+            "/subscription/refresh",
+            json={},
+            headers={"Origin": ALLOWED_ORIGIN},
+        )
+        assert resp.status == 200
+        assert (await resp.json()) == {"ok": True}
+        assert resp.headers["Access-Control-Allow-Origin"] == ALLOWED_ORIGIN
+        assert called["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_subscription_refresh_rejects_bad_origin():
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(
+            "/subscription/refresh",
+            json={},
+            headers={"Origin": "https://evil.com"},
+        )
+        assert resp.status == 403
+        assert "Access-Control-Allow-Origin" not in resp.headers
+
+
+# -- /ping -------------------------------------------------------------------
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Replaces the per-endpoint CORS header dicts and separate preflight handlers with one middleware. The three browser-facing paths (`/auth/callback`, `/subscription/refresh`, `/ping`) share a single implementation of preflight handling and response decoration, including the `Access-Control-Allow-Private-Network` header.
- **Drops the origin allowlist.** The old code restricted `/auth/callback` and `/subscription/refresh` to `smart-notes.xyz`. The CSRF attack this defended against — a malicious page overwriting the user's JWT — would only redirect API costs to the attacker's own account, which isn't a threat model worth the code. Any origin now gets echoed back and the request is served.
- Replaces the old TypedDict + `.get()`-and-string-check param extraction with dacite-validated dataclasses that mirror the camelCase JSON wire contract. Missing or wrong-typed fields now raise `ParamError` at the boundary with a clear message (e.g. `"noteType is required"`).
- Splits the `/` RPC `action` dispatch into a module-level `ACTIONS: dict[str, ActionHandler]` registry; each action becomes a top-level `async` function. The external contract (`{action, version, params}` → `{result, error}`) is unchanged.

Note: option/model string fields on the request dataclasses are deliberately `Optional[str]` rather than the `Literal` unions from `models.py` — a strict dacite check there would reject any newly-added model before the add-on updates.

`dacite` is added to the vendored-deps list in `scripts/build.sh` (already in `requirements.txt`).

## Verification

**Automated**
- `./scripts/build.sh check` — `ruff format --check`, `ruff check`, `pyright`: all green.
- `pytest` — 96/96 tests pass, including the rewritten `test_local_server.py` suite.
- TCP-level smoke test: spun up the real `LocalServer` in its background thread on `127.0.0.1:8766` and hit every endpoint with `urllib`. Confirmed: `/ping`, `/auth/callback`, `/subscription/refresh` all echo whatever `Origin` the caller sent (including unknown origins), `OPTIONS` preflights return 204 with the CORS + PNA headers, the RPC `/` endpoint remains free of CORS headers (intentional — not browser-facing), and `server.stop()` shuts down cleanly.

**Not performed**
- Anki launch via `/anki` — headless Linux host with no Anki install. The `LocalServer` lifecycle and all HTTP behavior was verified via the TCP smoke test above, but the plugin-in-Anki launch path was not exercised end-to-end.

## Claude session
- Working directory: `/home/michael/development/anki-smart-notes-master/anki-smart-notes`
- Session ID: `6fb6c964-c1aa-492e-9b9d-78696c8a5809`