### PR TITLE
feat: add client telemetry metadata

### DIFF
--- a/src/chat_provider.py
+++ b/src/chat_provider.py
@@ -17,12 +17,12 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import cast
+from typing import Optional, cast
 
 from .api_client import api
 from .constants import CHAT_CLIENT_TIMEOUT_SEC, DEFAULT_TEMPERATURE
 from .logger import logger
-from .models import ChatModels, ChatProviders
+from .models import ChatModels, ChatProviders, GenerationExtra
 
 
 class ChatProvider:
@@ -34,16 +34,21 @@ class ChatProvider:
         note_id: int,
         temperature: float = DEFAULT_TEMPERATURE,
         web_search: bool = False,
+        extra: Optional[GenerationExtra] = None,
     ) -> str:
+        args: dict[str, object] = {
+            "provider": provider,
+            "model": model,
+            "message": prompt,
+            "temperature": temperature,
+            "web_search": web_search,
+        }
+        if extra:
+            args["extra"] = extra
+
         response = await api.get_api_response(
             path="chat",
-            args={
-                "provider": provider,
-                "model": model,
-                "message": prompt,
-                "temperature": temperature,
-                "web_search": web_search,
-            },
+            args=args,
             note_id=note_id,
             timeout_sec=CHAT_CLIENT_TIMEOUT_SEC,
         )

--- a/src/field_processor.py
+++ b/src/field_processor.py
@@ -37,6 +37,7 @@ from .models import (
     ChatModels,
     ChatProviders,
     ElevenVoices,
+    GenerationSource,
     ImageModels,
     ImageProviders,
     OpenAIVoices,
@@ -182,6 +183,7 @@ class FieldProcessor:
         should_convert_to_html: bool,
         web_search: bool = False,
         show_error_box: bool = True,
+        generation_source: GenerationSource = "card_generation",
     ) -> Optional[str]:
         interpolated_prompt = interpolate_prompt(prompt, note)
 
@@ -198,6 +200,7 @@ class FieldProcessor:
                 temperature=temperature,
                 note_id=note.id,
                 web_search=web_search,
+                extra={"generation_source": generation_source},
             )
         elif has_api_key():
             logger.debug("On legacy path....")
@@ -237,6 +240,7 @@ class FieldProcessor:
         voice: str,
         strip_html: bool,
         show_error_box: bool = True,
+        generation_source: GenerationSource = "card_generation",
     ) -> Optional[bytes]:
         interpolated_prompt = interpolate_prompt(input_text, note)
 
@@ -258,6 +262,7 @@ class FieldProcessor:
             voice=voice,
             note_id=note.id,
             strip_html=strip_html,
+            extra={"generation_source": generation_source},
         )
 
     async def get_image_response(
@@ -267,6 +272,7 @@ class FieldProcessor:
         model: ImageModels,
         provider: ImageProviders,
         show_error_box: bool = True,
+        generation_source: GenerationSource = "card_generation",
     ) -> Optional[ImageResponse]:
         if not is_capacity_remaining():
             logger.debug("App at capacity, returning early")
@@ -280,7 +286,11 @@ class FieldProcessor:
             return None
 
         return await self.image_provider.async_get_image_response(
-            prompt=interpolated_prompt, model=model, provider=provider, note_id=note.id
+            prompt=interpolated_prompt,
+            model=model,
+            provider=provider,
+            note_id=note.id,
+            extra={"generation_source": generation_source},
         )
 
 

--- a/src/image_provider.py
+++ b/src/image_provider.py
@@ -17,11 +17,11 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 from .api_client import api
 from .constants import IMAGE_PROVIDER_TIMEOUT_SEC
-from .models import ImageModels, ImageProviders
+from .models import GenerationExtra, ImageModels, ImageProviders
 
 
 class ImageResponse(TypedDict):
@@ -31,13 +31,20 @@ class ImageResponse(TypedDict):
 
 class ImageProvider:
     async def async_get_image_response(
-        self, prompt: str, model: ImageModels, provider: ImageProviders, note_id: int
+        self,
+        prompt: str,
+        model: ImageModels,
+        provider: ImageProviders,
+        note_id: int,
+        extra: Optional[GenerationExtra] = None,
     ) -> ImageResponse:
-        args: dict[str, str] = {
+        args: dict[str, object] = {
             "provider": provider,
             "model": model,
             "prompt": prompt,
         }
+        if extra:
+            args["extra"] = extra
 
         response = await api.get_api_response(
             path="image",

--- a/src/models.py
+++ b/src/models.py
@@ -115,6 +115,14 @@ OpenAIVoices = Literal[
 ElevenVoices = Literal["male-1", "male-2", "female-1", "female-2"]
 
 SmartFieldType = Literal["chat", "tts", "image"]
+GenerationSource = Literal[
+    "card_generation", "prompt_test", "custom_field", "voice_test"
+]
+
+
+class GenerationExtra(TypedDict):
+    generation_source: GenerationSource
+
 
 # Image Models
 

--- a/src/sentry.py
+++ b/src/sentry.py
@@ -214,27 +214,35 @@ class Sentry:
 
 
 def pinger(event: str) -> Callable[[], Coroutine[Any, Any, None]]:
-    user_state = (
-        "subscriber"
-        if config.auth_token
-        else ("legacy" if config.openai_api_key else "inactive")
-    )
-    ping_url = f"{get_server_url()}/ping"
-    params = {
-        "version": get_version(),
-        "uuid": config.uuid,
-        "event": event,
-        "userState": user_state,
-    }
-
     async def ping() -> None:
+        headers = None
+        if config.auth_token:
+            ping_url = f"{get_server_url()}/api/ping"
+            params = {
+                "version": get_version(),
+                "event": event,
+                "userState": "subscriber",
+            }
+            headers = {"Authorization": f"Bearer {config.auth_token}"}
+        elif config.openai_api_key:
+            ping_url = f"{get_server_url()}/ping"
+            params = {
+                "version": get_version(),
+                "uuid": config.uuid,
+                "event": event,
+                "userState": "legacy",
+            }
+        else:
+            logger.debug("Skipping ping for inactive unauthenticated user")
+            return
+
         try:
             # 10s timeout for users who can't connect for some reason (china/vpn etc)
             async with (
                 aiohttp.ClientSession(
                     timeout=aiohttp.ClientTimeout(total=10)
                 ) as session,
-                session.get(ping_url, params=params) as response,
+                session.get(ping_url, params=params, headers=headers) as response,
             ):
                 if response.status != 200:
                     logger.error(f"Error pinging server: {response.status}")

--- a/src/tts_provider.py
+++ b/src/tts_provider.py
@@ -17,9 +17,11 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from typing import Optional
+
 from .api_client import api
 from .constants import TTS_PROVIDER_TIMEOUT_SEC
-from .models import TTSModels, TTSProviders
+from .models import GenerationExtra, TTSModels, TTSProviders
 
 
 class TTSProvider:
@@ -31,16 +33,21 @@ class TTSProvider:
         voice: str,
         strip_html: bool,
         note_id: int = -1,
+        extra: Optional[GenerationExtra] = None,
     ) -> bytes:
+        args: dict[str, object] = {
+            "provider": provider,
+            "model": model,
+            "message": input,
+            "voice": voice,
+            "stripHtml": strip_html,
+        }
+        if extra:
+            args["extra"] = extra
+
         response = await api.get_api_response(
             path="tts",
-            args={
-                "provider": provider,
-                "model": model,
-                "message": input,
-                "voice": voice,
-                "stripHtml": strip_html,
-            },
+            args=args,
             note_id=note_id,
             timeout_sec=TTS_PROVIDER_TIMEOUT_SEC,
         )

--- a/src/ui/custom_prompt.py
+++ b/src/ui/custom_prompt.py
@@ -261,6 +261,7 @@ class CustomTextPrompt(CustomPrompt):
                     "chat_markdown_to_html"
                 ],
                 web_search=self._chat_options.state.s["chat_web_search"],
+                generation_source="custom_field",
             )
 
         run_async_in_background_with_sentry(generate_text, on_success, on_error)
@@ -312,6 +313,7 @@ class CustomImagePrompt(CustomPrompt):
                 input_text=prompt,
                 model=self.image_options.state.s["image_model"],
                 provider=self.image_options.state.s["image_provider"],
+                generation_source="custom_field",
             )
 
         run_async_in_background_with_sentry(generate_image, on_success, on_error)
@@ -385,6 +387,7 @@ class CustomTTSPrompt(CustomPrompt):
                 provider=self.tts_options.state.s["tts_provider"],
                 voice=self.tts_options.state.s["tts_voice"],
                 strip_html=True,
+                generation_source="custom_field",
             )
 
         def on_success(audio: Optional[bytes]):

--- a/src/ui/prompt_dialog.py
+++ b/src/ui/prompt_dialog.py
@@ -733,6 +733,7 @@ class PromptDialog(QDialog):
                         self.chat_options.state.s, "chat_temperature"
                     ),
                     should_convert_to_html=False,  # Don't show HTML here bc it's confusing
+                    generation_source="prompt_test",
                 )
 
             run_async_in_background_with_sentry(chat_fn, on_success, on_failure)
@@ -748,6 +749,7 @@ class PromptDialog(QDialog):
                     strip_html=none_defaulting(
                         self.tts_options.state.s, "tts_strip_html", True
                     ),
+                    generation_source="prompt_test",
                 )
 
             run_async_in_background_with_sentry(tts_fn, on_success, on_failure)
@@ -759,6 +761,7 @@ class PromptDialog(QDialog):
                     note=sample_note,
                     model="flux-dev",
                     provider="replicate",
+                    generation_source="prompt_test",
                 )
 
             run_async_in_background_with_sentry(img_fn, on_success, on_failure)

--- a/src/ui/tts_options.py
+++ b/src/ui/tts_options.py
@@ -567,6 +567,7 @@ class TTSOptions(QWidget):
                 provider=provider,
                 voice=voice,
                 strip_html=(none_defaulting(self.state.s, "tts_strip_html", True)),
+                extra={"generation_source": "voice_test"},
             )
             return resp
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -87,6 +87,7 @@ class MockChatClient:
         temperature: int = 0,
         retry_count: int = 0,
         web_search: bool = False,
+        extra: Any = None,
     ) -> str:
         return p(prompt)
 


### PR DESCRIPTION
## Summary
- Send authenticated pings to `/api/ping` and keep legacy OpenAI-only pings on public `/ping`.
- Add optional generation metadata to chat, TTS, and image API payloads.
- Mark generation source for card generation, prompt tests, custom field generation, and voice tests.

## Verification
- `./scripts/build.sh check`
- `python -m pytest`
- Anki launch/E2E not run: Anki is not installed in this Linux environment (`anki` and `/Applications/Anki.app/Contents/MacOS/launcher` unavailable).

## Agent session metadata
- Working directory: `/home/michael/development/anki-smart-notes-master/anki-smart-notes`
- Session ID: `019de398-9c68-79a0-86d1-99feb0503f54`