### PR TITLE
fix: show server error messages in client [ANK-406]

### DIFF
--- a/src/api_client.py
+++ b/src/api_client.py
@@ -32,6 +32,10 @@ class OutOfCreditsError(Exception):
     pass
 
 
+class ClientFacingAPIError(Exception):
+    pass
+
+
 class APIClient:
     async def get_api_response(
         self,
@@ -85,6 +89,11 @@ class APIClient:
                 json = await response.json()
                 logger.error(json)
                 raise Exception(f"Validation error: {json['error']}")
+            if response.status == 413:
+                json = await response.json()
+                message = json.get("message")
+                if isinstance(message, str):
+                    raise ClientFacingAPIError(message)
             response.raise_for_status()
 
             # Read it all into memory

--- a/src/api_client.py
+++ b/src/api_client.py
@@ -92,12 +92,12 @@ class APIClient:
                     json = None
 
                 if isinstance(json, dict):
-                    if response.status == 400:
-                        logger.error(json)
-
                     message = json.get("message") or json.get("error")
                     if isinstance(message, str):
                         raise ClientFacingAPIError(message)
+
+                    if response.status == 400:
+                        logger.error(json)
 
             response.raise_for_status()
 

--- a/src/note_proccessor.py
+++ b/src/note_proccessor.py
@@ -266,12 +266,12 @@ class NoteProcessor:
             if isinstance(result, OutOfCreditsError):
                 hit_out_of_credits = True
                 failed.append(note)
+            elif isinstance(result, ClientFacingAPIError):
+                # Keep this below error level so expected per-note failures do not
+                # become Sentry events through the logging integration.
+                logger.info(f"Client-facing error processing note {note_ids[i]}")
+                failed.append(note)
             elif isinstance(result, Exception):
-                if isinstance(result, ClientFacingAPIError):
-                    logger.info(f"Client-facing error processing note {note_ids[i]}")
-                    failed.append(note)
-                    continue
-
                 logger.error(
                     f"Error processing note {note_ids[i]}: {result}, {''.join(traceback.format_exception(type(result), result, result.__traceback__))}"
                 )
@@ -311,7 +311,7 @@ class NoteProcessor:
             on_success(updated)
 
         def wrapped_failure(e: Exception) -> None:
-            self._handle_failure(e)
+            self._handle_single_card_failure(e)
             if on_failure:
                 on_failure(e)
 
@@ -439,7 +439,7 @@ class NoteProcessor:
 
         return did_update
 
-    def _handle_failure(self, e: Exception) -> None:
+    def _handle_single_card_failure(self, e: Exception) -> None:
         logger.debug("Handling failure")
 
         if isinstance(e, OutOfCreditsError):

--- a/src/note_proccessor.py
+++ b/src/note_proccessor.py
@@ -269,7 +269,9 @@ class NoteProcessor:
             elif isinstance(result, ClientFacingAPIError):
                 # Keep this below error level so expected per-note failures do not
                 # become Sentry events through the logging integration.
-                logger.info(f"Client-facing error processing note {note_ids[i]}")
+                logger.info(
+                    f"Client-facing error processing note {note_ids[i]}: {result}"
+                )
                 failed.append(note)
             elif isinstance(result, Exception):
                 logger.error(

--- a/src/note_proccessor.py
+++ b/src/note_proccessor.py
@@ -30,7 +30,7 @@ from anki.decks import DeckId
 from anki.notes import Note, NoteId
 from aqt import mw
 
-from .api_client import OutOfCreditsError
+from .api_client import ClientFacingAPIError, OutOfCreditsError
 from .app_state import (
     app_state,
     has_api_key,
@@ -76,6 +76,7 @@ class NoteProcessor:
         self.config = config
         self.batch_in_progress = False
         self._cancelled = threading.Event()
+        self._batch_client_error_message: Optional[str] = None
 
     def process_cards_with_progress(
         self,
@@ -111,6 +112,7 @@ class NoteProcessor:
 
         self.batch_in_progress = True
         self._cancelled.clear()
+        self._batch_client_error_message = None
 
         def wrapped_on_success(res: tuple[list[Note], list[Note], list[Note]]) -> None:
             updated, failed, skipped = res
@@ -214,6 +216,13 @@ class NoteProcessor:
             if hit_out_of_credits:
                 raise OutOfCreditsError()
 
+            if self._batch_client_error_message:
+                run_on_main(
+                    lambda message=self._batch_client_error_message: show_message_box(
+                        message
+                    )
+                )
+
             return total_updated, total_failed, total_skipped
 
         run_async_in_background_with_sentry(op, wrapped_on_success, on_failure)
@@ -267,6 +276,12 @@ class NoteProcessor:
                 hit_out_of_credits = True
                 failed.append(note)
             elif isinstance(result, Exception):
+                if (
+                    isinstance(result, ClientFacingAPIError)
+                    and self.batch_in_progress
+                    and self._batch_client_error_message is None
+                ):
+                    self._batch_client_error_message = str(result)
                 logger.error(
                     f"Error processing note {note_ids[i]}: {result}, {''.join(traceback.format_exception(type(result), result, result.__traceback__))}"
                 )
@@ -439,6 +454,10 @@ class NoteProcessor:
 
         if isinstance(e, OutOfCreditsError):
             app_state.update_subscription_state()
+            return
+
+        if isinstance(e, ClientFacingAPIError):
+            show_message_box(str(e))
             return
 
         openai_failure_map = {

--- a/src/note_proccessor.py
+++ b/src/note_proccessor.py
@@ -76,7 +76,6 @@ class NoteProcessor:
         self.config = config
         self.batch_in_progress = False
         self._cancelled = threading.Event()
-        self._batch_client_error_message: Optional[str] = None
 
     def process_cards_with_progress(
         self,
@@ -112,7 +111,6 @@ class NoteProcessor:
 
         self.batch_in_progress = True
         self._cancelled.clear()
-        self._batch_client_error_message = None
 
         def wrapped_on_success(res: tuple[list[Note], list[Note], list[Note]]) -> None:
             updated, failed, skipped = res
@@ -216,13 +214,6 @@ class NoteProcessor:
             if hit_out_of_credits:
                 raise OutOfCreditsError()
 
-            if self._batch_client_error_message:
-                run_on_main(
-                    lambda message=self._batch_client_error_message: show_message_box(
-                        message
-                    )
-                )
-
             return total_updated, total_failed, total_skipped
 
         run_async_in_background_with_sentry(op, wrapped_on_success, on_failure)
@@ -277,11 +268,6 @@ class NoteProcessor:
                 failed.append(note)
             elif isinstance(result, Exception):
                 if isinstance(result, ClientFacingAPIError):
-                    if (
-                        self.batch_in_progress
-                        and self._batch_client_error_message is None
-                    ):
-                        self._batch_client_error_message = str(result)
                     logger.info(f"Client-facing error processing note {note_ids[i]}")
                     failed.append(note)
                     continue

--- a/src/review_time_evaluator.py
+++ b/src/review_time_evaluator.py
@@ -194,7 +194,7 @@ class ReviewTimeEvaluator:
             if isinstance(e, ClientFacingAPIError):
                 # Keep this below error level so expected per-card failures do not
                 # become Sentry events through the logging integration.
-                logger.info(f"Client-facing error prepping card {card.id}")
+                logger.info(f"Client-facing error prepping card {card.id}: {e}")
             else:
                 logger.error(
                     f"Error prepping card {card.id}: {e}, {''.join(traceback.format_exception(type(e), e, e.__traceback__))}"

--- a/src/review_time_evaluator.py
+++ b/src/review_time_evaluator.py
@@ -192,6 +192,8 @@ class ReviewTimeEvaluator:
             raise
         except Exception as e:
             if isinstance(e, ClientFacingAPIError):
+                # Keep this below error level so expected per-card failures do not
+                # become Sentry events through the logging integration.
                 logger.info(f"Client-facing error prepping card {card.id}")
             else:
                 logger.error(

--- a/src/sentry.py
+++ b/src/sentry.py
@@ -19,6 +19,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 
 # pyright: reportPrivateUsage=false
 
+import asyncio
 import base64
 import json
 import logging
@@ -34,7 +35,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.session import Session
 
 from . import env
-from .api_client import OutOfCreditsError
+from .api_client import ClientFacingAPIError, OutOfCreditsError
 from .config import config
 from .logger import logger
 from .tasks import run_async_in_background
@@ -155,7 +156,12 @@ class Sentry:
         async def wrapped(*args: Any, **kwargs: Any):
             try:
                 return await fn(*args, **kwargs)
-            except (OutOfCreditsError, TimeoutError):
+            except (
+                ClientFacingAPIError,
+                OutOfCreditsError,
+                TimeoutError,
+                asyncio.TimeoutError,
+            ):
                 # These expected failures are reraised without Sentry reporting.
                 raise
             except Exception as e:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -170,6 +170,7 @@ async def test_api_client_raises_client_facing_message_for_server_error_field(
 async def test_api_client_raises_client_facing_message_for_validation_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    error_logs: list[object] = []
     fake_session = FakeSession()
     fake_session.response_status = 400
     fake_session.response_json = {"error": "Provider is required"}
@@ -179,11 +180,36 @@ async def test_api_client_raises_client_facing_message_for_validation_errors(
     )
     monkeypatch.setattr(api_client, "get_server_url", lambda: "https://server.test")
     monkeypatch.setattr(api_client, "get_version", lambda: "1.2.3")
+    monkeypatch.setattr(api_client.logger, "error", error_logs.append)
 
     with pytest.raises(api_client.ClientFacingAPIError, match="Provider is required"):
         await api_client.APIClient().get_api_response("tts", {"message": "hello"})
 
     assert len(fake_session.calls) == 1
+    assert error_logs == []
+
+
+@pytest.mark.asyncio
+async def test_api_client_logs_non_client_facing_validation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error_logs: list[object] = []
+    fake_session = FakeSession()
+    fake_session.response_status = 400
+    fake_session.response_json = {"details": "invalid request"}
+    monkeypatch.setattr(api_client.aiohttp, "ClientSession", lambda: fake_session)
+    monkeypatch.setattr(
+        api_client, "config", type("Config", (), {"auth_token": "test-token"})()
+    )
+    monkeypatch.setattr(api_client, "get_server_url", lambda: "https://server.test")
+    monkeypatch.setattr(api_client, "get_version", lambda: "1.2.3")
+    monkeypatch.setattr(api_client.logger, "error", error_logs.append)
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await api_client.APIClient().get_api_response("tts", {"message": "hello"})
+
+    assert len(fake_session.calls) == 1
+    assert error_logs == [{"details": "invalid request"}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -29,6 +29,7 @@ from src import api_client
 class FakeResponse:
     def __init__(self, status: int = 204) -> None:
         self.status = status
+        self.json_body: dict[str, object] = {}
 
     async def __aenter__(self) -> "FakeResponse":
         return self
@@ -49,9 +50,13 @@ class FakeResponse:
     async def read(self) -> bytes:
         return b""
 
+    async def json(self) -> dict[str, object]:
+        return self.json_body
+
 
 class FakeSession:
     response_status = 204
+    response_json: dict[str, object] = {}
     request_error: Optional[Exception] = None
 
     def __init__(self) -> None:
@@ -67,7 +72,9 @@ class FakeSession:
         self.calls.append({"endpoint": endpoint, **kwargs})
         if self.request_error:
             raise self.request_error
-        return FakeResponse(self.response_status)
+        response = FakeResponse(self.response_status)
+        response.json_body = self.response_json
+        return response
 
 
 @pytest.mark.asyncio
@@ -109,6 +116,29 @@ async def test_api_client_does_not_retry_server_rate_limits(
 
     with pytest.raises(aiohttp.ClientResponseError):
         await api_client.APIClient().get_api_response("chat", {"message": "hello"})
+
+    assert len(fake_session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_api_client_raises_client_facing_message_for_payload_too_large(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    message = (
+        "This request is too long for Google Voice. Please try a different provider."
+    )
+    fake_session = FakeSession()
+    fake_session.response_status = 413
+    fake_session.response_json = {"message": message}
+    monkeypatch.setattr(api_client.aiohttp, "ClientSession", lambda: fake_session)
+    monkeypatch.setattr(
+        api_client, "config", type("Config", (), {"auth_token": "test-token"})()
+    )
+    monkeypatch.setattr(api_client, "get_server_url", lambda: "https://server.test")
+    monkeypatch.setattr(api_client, "get_version", lambda: "1.2.3")
+
+    with pytest.raises(api_client.ClientFacingAPIError, match=message):
+        await api_client.APIClient().get_api_response("tts", {"message": "hello"})
 
     assert len(fake_session.calls) == 1
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -19,9 +19,12 @@ You should have received a copy of the GNU General Public License
 along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import asyncio
+
 import pytest
 from fixtures import NOTE_TYPE_ID, NOTE_TYPE_NAME, MockCard, MockConfig, MockNote
 
+from src.api_client import ClientFacingAPIError
 from src.database.migrations import apply_database_migrations
 
 
@@ -29,6 +32,10 @@ def p(str) -> str:
     # Avoid underscores so markdown-to-html conversion (always-on) is a no-op
     # on the simulated chat output.
     return f"p-{str}"
+
+
+async def _raise_client_facing_error(message: str) -> bool:
+    raise ClientFacingAPIError(message)
 
 
 class MockOpenAIClient:
@@ -542,6 +549,143 @@ def test_process_cards_with_progress_noops_during_batch(monkeypatch):
 
     assert calls == []
     assert processor.batch_in_progress
+
+
+@pytest.mark.asyncio
+async def test_process_notes_batch_records_one_client_facing_error(monkeypatch):
+    import src.note_proccessor
+    from src.note_proccessor import NoteProcessor
+
+    message = (
+        "This request is too long for Google Voice. Please try a different provider."
+    )
+    notes = {
+        1: MockNote({"f1": "1"}, note_id=1),
+        2: MockNote({"f1": "2"}, note_id=2),
+    }
+
+    class MockCollection:
+        def get_note(self, note_id):
+            return notes[note_id]
+
+    class MockMw:
+        col = MockCollection()
+
+    processor = NoteProcessor(  # type: ignore
+        field_resolver=None,
+        config=MockConfig(prompts_map={}, allow_empty_fields=False),
+    )
+    processor.batch_in_progress = True
+    monkeypatch.setattr(src.note_proccessor, "mw", MockMw())
+    monkeypatch.setattr(
+        src.note_proccessor.smart_field_service,
+        "get_smart_fields_for_note",
+        lambda *args, **kwargs: [object()],
+    )
+    monkeypatch.setattr(
+        processor,
+        "process_note",
+        lambda *args, **kwargs: _raise_client_facing_error(message),
+    )
+
+    updated, failed, skipped, out_of_credits = await processor._process_notes_batch(
+        [1, 2],
+        overwrite_fields=False,
+        did_map={1: 1, 2: 1},
+    )
+
+    assert updated == []
+    assert failed == [notes[1], notes[2]]
+    assert skipped == []
+    assert not out_of_credits
+    assert processor._batch_client_error_message == message
+
+
+@pytest.mark.asyncio
+async def test_process_cards_with_progress_shows_one_client_facing_error(
+    monkeypatch,
+):
+    import src.note_proccessor
+    from src.note_proccessor import NoteProcessor
+
+    message = (
+        "This request is too long for Google Voice. Please try a different provider."
+    )
+    notes = {
+        1: MockNote({"f1": "1"}, note_id=1),
+        2: MockNote({"f1": "2"}, note_id=2),
+    }
+    cards = {
+        1: MockCard(id=1, did=1, note=notes[1]),
+        2: MockCard(id=2, did=1, note=notes[2]),
+    }
+    cards[1].nid = 1
+    cards[2].nid = 2
+    shown_messages = []
+
+    class MockCollection:
+        def get_card(self, card_id):
+            return cards[card_id]
+
+        def update_notes(self, updated):
+            pass
+
+    class MockProgress:
+        def start(self, **kwargs):
+            pass
+
+        def finish(self):
+            pass
+
+        def update(self, **kwargs):
+            pass
+
+        def want_cancel(self):
+            return False
+
+    class MockMw:
+        col = MockCollection()
+        progress = MockProgress()
+
+    async def process_notes_batch(*args, **kwargs):
+        processor._batch_client_error_message = message
+        return [], [notes[1], notes[2]], [], False
+
+    async def run_background(op, on_success, on_failure=None, **kwargs):
+        try:
+            on_success(await op())
+        except Exception as exc:
+            if on_failure:
+                on_failure(exc)
+
+    processor = NoteProcessor(  # type: ignore
+        field_resolver=None,
+        config=MockConfig(prompts_map={}, allow_empty_fields=False),
+    )
+    monkeypatch.setattr(src.note_proccessor, "mw", MockMw())
+    monkeypatch.setattr(processor, "_assert_valid_app_mode", lambda: True)
+    monkeypatch.setattr(src.note_proccessor, "bump_usage_counter", lambda: None)
+    monkeypatch.setattr(
+        src.note_proccessor,
+        "is_capacity_remaining_or_legacy",
+        lambda show_box=False: True,
+    )
+    monkeypatch.setattr(src.note_proccessor, "is_capacity_remaining", lambda: True)
+    monkeypatch.setattr(src.note_proccessor, "run_on_main", lambda work: work())
+    monkeypatch.setattr(
+        src.note_proccessor,
+        "run_async_in_background_with_sentry",
+        lambda op, on_success, on_failure=None, **kwargs: asyncio.create_task(
+            run_background(op, on_success, on_failure, **kwargs)
+        ),
+    )
+    monkeypatch.setattr(src.note_proccessor, "show_message_box", shown_messages.append)
+    monkeypatch.setattr(processor, "_process_notes_batch", process_notes_batch)
+
+    processor.process_cards_with_progress([1, 2], on_success=None)
+    await asyncio.sleep(0)
+
+    assert shown_messages == [message]
 
 
 @pytest.mark.asyncio

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -552,7 +552,7 @@ def test_process_cards_with_progress_noops_during_batch(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_process_notes_batch_records_one_client_facing_error(monkeypatch):
+async def test_process_notes_batch_marks_client_facing_errors_as_failed(monkeypatch):
     import src.note_proccessor
     from src.note_proccessor import NoteProcessor
 
@@ -602,7 +602,6 @@ async def test_process_notes_batch_records_one_client_facing_error(monkeypatch):
     assert failed == [notes[1], notes[2]]
     assert skipped == []
     assert not out_of_credits
-    assert processor._batch_client_error_message == message
     assert error_logs == []
     assert info_logs == [
         "Client-facing error processing note 1",
@@ -611,15 +610,12 @@ async def test_process_notes_batch_records_one_client_facing_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_process_cards_with_progress_shows_one_client_facing_error(
+async def test_process_cards_with_progress_does_not_show_client_facing_error(
     monkeypatch,
 ):
     import src.note_proccessor
     from src.note_proccessor import NoteProcessor
 
-    message = (
-        "This request is too long for Google TTS. Please try a different provider."
-    )
     notes = {
         1: MockNote({"f1": "1"}, note_id=1),
         2: MockNote({"f1": "2"}, note_id=2),
@@ -657,7 +653,6 @@ async def test_process_cards_with_progress_shows_one_client_facing_error(
         progress = MockProgress()
 
     async def process_notes_batch(*args, **kwargs):
-        processor._batch_client_error_message = message
         return [], [notes[1], notes[2]], [], False
 
     async def run_background(op, on_success, on_failure=None, **kwargs):
@@ -694,7 +689,7 @@ async def test_process_cards_with_progress_shows_one_client_facing_error(
     processor.process_cards_with_progress([1, 2], on_success=None)
     await asyncio.sleep(0)
 
-    assert shown_messages == [message]
+    assert shown_messages == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -604,8 +604,8 @@ async def test_process_notes_batch_marks_client_facing_errors_as_failed(monkeypa
     assert not out_of_credits
     assert error_logs == []
     assert info_logs == [
-        "Client-facing error processing note 1",
-        "Client-facing error processing note 2",
+        f"Client-facing error processing note 1: {message}",
+        f"Client-facing error processing note 2: {message}",
     ]
 
 

--- a/tests/test_review_time_evaluator.py
+++ b/tests/test_review_time_evaluator.py
@@ -386,5 +386,7 @@ async def test_run_card_task_logs_client_facing_errors_without_error_level(
 
     assert evaluator.in_flight == set()
     assert error_logs == []
-    assert info_logs == ["Client-facing error prepping card 1"]
+    assert info_logs == [
+        "Client-facing error prepping card 1: Try a different provider."
+    ]
     assert len(redraws) == 1

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -19,9 +19,12 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 
 # pyright: reportPrivateUsage=false
 
+import types
+
 import pytest
 
 import src.sentry as sentry_module
+from src.api_client import ClientFacingAPIError
 from src.sentry import Sentry
 
 
@@ -65,6 +68,60 @@ async def test_wrap_async_reraises_timeout_without_reporting_in_production(
         raise error
 
     with pytest.raises(TimeoutError, match="provider timed out"):
+        await sentry.wrap_async(op)()
+
+    assert captured == []
+    assert shown == []
+
+
+@pytest.mark.asyncio
+async def test_wrap_async_reraises_client_facing_api_error_without_reporting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[Exception] = []
+    shown: list[Exception] = []
+    error = ClientFacingAPIError("This request is too long for Google Voice.")
+    sentry = object.__new__(Sentry)
+
+    monkeypatch.setattr(sentry_module, "is_production", lambda: True)
+    monkeypatch.setattr(sentry, "capture_exception", lambda e: captured.append(e))
+    monkeypatch.setattr(sentry, "_show_error_message", lambda e: shown.append(e))
+
+    async def op() -> None:
+        raise error
+
+    with pytest.raises(ClientFacingAPIError, match="Google Voice"):
+        await sentry.wrap_async(op)()
+
+    assert captured == []
+    assert shown == []
+
+
+@pytest.mark.asyncio
+async def test_wrap_async_reraises_legacy_asyncio_timeout_without_reporting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class LegacyAsyncioTimeoutError(Exception):
+        pass
+
+    captured: list[Exception] = []
+    shown: list[Exception] = []
+    error = LegacyAsyncioTimeoutError("feature flags timed out")
+    sentry = object.__new__(Sentry)
+
+    monkeypatch.setattr(
+        sentry_module,
+        "asyncio",
+        types.SimpleNamespace(TimeoutError=LegacyAsyncioTimeoutError),
+    )
+    monkeypatch.setattr(sentry_module, "is_production", lambda: True)
+    monkeypatch.setattr(sentry, "capture_exception", lambda e: captured.append(e))
+    monkeypatch.setattr(sentry, "_show_error_message", lambda e: shown.append(e))
+
+    async def op() -> None:
+        raise error
+
+    with pytest.raises(LegacyAsyncioTimeoutError, match="feature flags timed out"):
         await sentry.wrap_async(op)()
 
     assert captured == []


### PR DESCRIPTION
## Summary

- parse server error responses with a JSON `message` or `error` string and raise a typed plugin exception containing that server-provided message
- show that message directly for single-note generation failures
- keep batch generation on the existing updated/failed/skipped summary UX; client-facing per-note errors are counted as failed notes but do not show provider-specific popups during batching
- avoid error-level logs and Sentry reporting for expected client-facing API errors in normal batch, review-time generation, and API-client classification paths
- merge current `origin/main` into the PR branch

## Why

The server can now choose which errors are safe and useful for users. The plugin should not special-case Google TTS; it should display server-provided client-facing messages generically for single-note flows while preserving the existing aggregate batch summary until batch failures can identify exactly which cards failed and why.

## Verification

- `./scripts/build.sh fix`
- `./scripts/build.sh check`
- `NO_PROXY='*' no_proxy='*' source .venv/bin/activate && python -m pytest -q tests/test_api_client.py tests/test_processor.py tests/test_sentry.py tests/test_review_time_evaluator.py` (`66 passed`)
- `NO_PROXY='*' no_proxy='*' source .venv/bin/activate && python -m pytest -q` (`184 passed`)
- local subagent code review completed; findings about error-level logging were fixed before final checks

## Agent session metadata

- Working directory: `/Users/michaelpiazza/development/smart_notes_all`
- Session ID: `019eef58-cd26-7b21-b351-9c181611c1cf`
