### PR TITLE
fix: suppress legacy asyncio feature flag timeouts [ANK-415]

### DIFF
--- a/src/sentry.py
+++ b/src/sentry.py
@@ -19,6 +19,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 
 # pyright: reportPrivateUsage=false
 
+import asyncio
 import base64
 import json
 import logging
@@ -155,8 +156,9 @@ class Sentry:
         async def wrapped(*args: Any, **kwargs: Any):
             try:
                 return await fn(*args, **kwargs)
-            except (OutOfCreditsError, TimeoutError):
-                # These expected failures are reraised without Sentry reporting.
+            except (OutOfCreditsError, TimeoutError, asyncio.TimeoutError):
+                # Older Anki runtimes may raise asyncio.TimeoutError as a
+                # distinct class from built-in TimeoutError.
                 raise
             except Exception as e:
                 if is_production():

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -19,6 +19,8 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 
 # pyright: reportPrivateUsage=false
 
+import types
+
 import pytest
 
 import src.sentry as sentry_module
@@ -65,6 +67,39 @@ async def test_wrap_async_reraises_timeout_without_reporting_in_production(
         raise error
 
     with pytest.raises(TimeoutError, match="provider timed out"):
+        await sentry.wrap_async(op)()
+
+    assert captured == []
+    assert shown == []
+
+
+@pytest.mark.asyncio
+async def test_wrap_async_reraises_legacy_asyncio_timeout_without_reporting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class LegacyAsyncioTimeoutError(Exception):
+        pass
+
+    captured: list[Exception] = []
+    shown: list[Exception] = []
+    error = LegacyAsyncioTimeoutError("feature flags timed out")
+    sentry = object.__new__(Sentry)
+
+    # Simulate older Anki runtimes where asyncio.TimeoutError is not an alias
+    # for built-in TimeoutError.
+    monkeypatch.setattr(
+        sentry_module,
+        "asyncio",
+        types.SimpleNamespace(TimeoutError=LegacyAsyncioTimeoutError),
+    )
+    monkeypatch.setattr(sentry_module, "is_production", lambda: True)
+    monkeypatch.setattr(sentry, "capture_exception", lambda e: captured.append(e))
+    monkeypatch.setattr(sentry, "_show_error_message", lambda e: shown.append(e))
+
+    async def op() -> None:
+        raise error
+
+    with pytest.raises(LegacyAsyncioTimeoutError, match="feature flags timed out"):
         await sentry.wrap_async(op)()
 
     assert captured == []


### PR DESCRIPTION
## Summary
- suppress Sentry reporting for legacy `asyncio.TimeoutError` from async plugin operations
- add regression coverage for older Anki runtimes where `asyncio.TimeoutError` is distinct from built-in `TimeoutError`

## Root cause
APP-JJ was a direct timeout from `feature_flags._fetch_flags` while fetching `/feature-flags`. The previous timeout suppression covered built-in `TimeoutError`, which is enough on Python 3.11+, but older Anki runtimes can raise `asyncio.TimeoutError` as a distinct class from aiohttp. That fell through the generic Sentry reporting path.

## Verification
- `/Users/michaelpiazza/development/smart_notes_all/anki-smart-notes/.venv/bin/python -m pytest tests/test_sentry.py`
- `/Users/michaelpiazza/development/smart_notes_all/anki-smart-notes/.venv/bin/python -m pytest` (176 passed)
- `PATH="/Users/michaelpiazza/development/smart_notes_all/anki-smart-notes/.venv/bin:$PATH" ./scripts/build.sh check`
- Lightweight Opus review: no correctness findings; addressed requested clarifying comments

Anki startup smoke was skipped by user direction. A preliminary worktree launch also hit the known worktree dependency issue: Anki app Python could not import `dotenv` from the live-linked worktree.

## Agent session metadata
- Working directory: `/Users/michaelpiazza/development/smart_notes_all`
- Session ID: `019eef80-52ec-7e11-b689-6babdd42a12c`