### PR TITLE
fix: backfill deprecated flux-schnell image settings [ANK-423]

### DIFF
--- a/src/database/db_migrations/0004_migrate_deprecated_image_models.py
+++ b/src/database/db_migrations/0004_migrate_deprecated_image_models.py
@@ -1,0 +1,40 @@
+"""
+Copyright (C) 2024 Michael Piazza
+
+This file is part of Smart Notes.
+
+Smart Notes is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Smart Notes is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from yoyo import step
+
+steps = [
+    step(
+        """
+        UPDATE default_image_generation_settings
+        SET provider = 'replicate', model = 'z-image-turbo'
+        WHERE model = 'flux-schnell';
+        """,
+        "SELECT 1;",
+    ),
+    step(
+        """
+        UPDATE image_smart_field_settings
+        SET provider = 'replicate', model = 'z-image-turbo'
+        WHERE uses_default_generation_settings = 0
+            AND model = 'flux-schnell';
+        """,
+        "SELECT 1;",
+    ),
+]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -237,6 +237,72 @@ def test_deprecated_default_chat_model_migrates_to_auto(tmp_path: Path) -> None:
     assert row == ("auto", "auto")
 
 
+def test_deprecated_image_models_migrate_to_z_image_turbo(tmp_path: Path) -> None:
+    database_path = tmp_path / "smart_notes.sqlite3"
+    migrations_path = Path(__file__).parents[1] / "src" / "database" / "db_migrations"
+    migrations = read_migrations(str(migrations_path))
+    backend = get_sqlite_backend(str(database_path))
+
+    with backend.lock():
+        backend.apply_migrations(migrations[:1])
+
+    conn = sqlite3.connect(database_path)
+    try:
+        conn.execute(
+            """
+            UPDATE default_image_generation_settings
+            SET provider = 'replicate', model = 'flux-schnell'
+            WHERE id = 1
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO smart_fields (
+                id, profile_name, note_type_id, deck_id, target_field_name, field_type,
+                enabled, created_at, updated_at
+            )
+            VALUES ('image-field', '__test__', 1, 1, 'Image', 'image', 1, 'now', 'now')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO image_smart_field_settings (
+                smart_field_id, prompt_text, uses_default_generation_settings,
+                provider, model
+            )
+            VALUES ('image-field', 'draw {{Front}}', 0, 'replicate', 'flux-schnell')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with backend.lock():
+        backend.apply_migrations(migrations[1:])
+
+    conn = sqlite3.connect(database_path)
+    try:
+        default_row = conn.execute(
+            """
+            SELECT provider, model
+            FROM default_image_generation_settings
+            WHERE id = 1
+            """
+        ).fetchone()
+        custom_row = conn.execute(
+            """
+            SELECT provider, model
+            FROM image_smart_field_settings
+            WHERE smart_field_id = 'image-field'
+            """
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert default_row == ("replicate", "z-image-turbo")
+    assert custom_row == ("replicate", "z-image-turbo")
+
+
 def test_profile_scope_migration_allows_same_field_in_different_profiles(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_smart_field_migration.py
+++ b/tests/test_smart_field_migration.py
@@ -210,7 +210,7 @@ def test_migrate_legacy_smart_field_config_backfills_deprecated_image_models(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    image_field_extras = image_extras()
+    image_field_extras = cast(Any, image_extras())
     image_field_extras["image_provider"] = "replicate"
     image_field_extras["image_model"] = "flux-schnell"
 

--- a/tests/test_smart_field_migration.py
+++ b/tests/test_smart_field_migration.py
@@ -34,7 +34,10 @@ from fixtures import (
 )
 
 from src.database.legacy_config_migration import migrate_legacy_config_to_database
-from src.database.migrations import apply_database_bootstrap_migrations
+from src.database.migrations import (
+    apply_database_bootstrap_migrations,
+    apply_database_migrations,
+)
 from src.models import DEFAULT_EXTRAS, FieldExtras
 
 SECOND_PROFILE_NOTE_TYPE_ID = 456
@@ -201,6 +204,56 @@ def test_migrate_legacy_smart_field_config_imports_shared_note_type_name_across_
         ),
         ("__test__", NOTE_TYPE_ID, int(DECK_ID), "Back", "{{Front}}"),
     ]
+
+
+def test_migrate_legacy_smart_field_config_backfills_deprecated_image_models(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    image_field_extras = image_extras()
+    image_field_extras["image_provider"] = "replicate"
+    image_field_extras["image_model"] = "flux-schnell"
+
+    addon_config = {
+        "prompts_map": {
+            "note_types": {
+                "Basic": {
+                    "1": {
+                        "fields": {"Image": "draw {{Front}}"},
+                        "extras": {"Image": image_field_extras},
+                    }
+                }
+            }
+        },
+        "image_provider": "replicate",
+        "image_model": "flux-schnell",
+        "did_migrate_smart_fields_to_sqlite": False,
+    }
+    install_fake_anki(monkeypatch, addon_config, tmp_path)
+    install_migration_alert(monkeypatch, [])
+
+    migrate_legacy_config_to_database()
+    apply_database_migrations()
+
+    with sqlite3.connect(tmp_path / "smart_notes.sqlite3") as conn:
+        default_row = conn.execute(
+            """
+            SELECT provider, model
+            FROM default_image_generation_settings
+            WHERE id = 1
+            """
+        ).fetchone()
+        custom_row = conn.execute(
+            """
+            SELECT image.provider, image.model
+            FROM smart_fields sf
+            JOIN image_smart_field_settings image ON image.smart_field_id = sf.id
+            WHERE sf.target_field_name = 'Image'
+            """
+        ).fetchone()
+
+    assert default_row == ("replicate", "z-image-turbo")
+    assert custom_row == ("replicate", "z-image-turbo")
 
 
 def test_migrate_legacy_smart_field_config_imports_global_rows_for_each_matching_profile(


### PR DESCRIPTION
## Summary
- add SQLite migration `0004_migrate_deprecated_image_models.py` to backfill persisted `flux-schnell` image settings to `replicate` / `z-image-turbo`
- cover both direct database migration and legacy config import paths with regression tests

## Root cause
The old config-era migration path already normalized deprecated image model settings, but the newer SQLite Smart Fields path could still persist `flux-schnell`. When the options dialog later derived a provider from the stored model, it indexed a deprecated value and crashed.

## Impact
This keeps legacy image settings from surviving on a deprecated model value and prevents the options dialog crash tracked in `APP-K6` / `ANK-423`.

## Verification
- `python -m pytest tests/test_database.py -k deprecated_image_models_migrate_to_z_image_turbo`
- `python -m pytest tests/test_smart_field_migration.py -k backfills_deprecated_image_models`
- `python -m pytest`
- `./scripts/build.sh check`
- `./scripts/build.sh anki-local` (startup smoke; Smart Notes loaded and applied the new migration)

## Tracking
- Linear: [ANK-423](https://linear.app/anki-smart-notes/issue/ANK-423/fix-app-k6-migrate-deprecated-flux-schnell-image-settings)
- Sentry: [APP-K6](https://rosebud-74.sentry.io/issues/ANKI-SMART-NOTES-APP-K6)

## Agent session metadata
- Working directory: `/Users/michaelpiazza/development/smart_notes_all`
- Session ID: `019f10e4-5e46-7790-86d0-5968e917e2ed`
