### PR TITLE
fix: stop review-time generation during profile cleanup

### DIFF
--- a/src/hooks.py
+++ b/src/hooks.py
@@ -445,6 +445,8 @@ def cleanup() -> None:
         _local_server = None
 
     global _review_time_evaluator
+    if _review_time_evaluator is not None:
+        _review_time_evaluator.stop()
     _review_time_evaluator = None
 
     logger.info("Shutting down loggers")

--- a/src/review_time_evaluator.py
+++ b/src/review_time_evaluator.py
@@ -56,6 +56,13 @@ class ReviewTimeEvaluator:
         self.in_flight: set[CardId] = set()
         self.wave_in_progress = False
         self.pending_tick = False
+        self.is_stopped = False
+
+    def stop(self) -> None:
+        self.is_stopped = True
+        self.pending_tick = False
+        self.wave_in_progress = False
+        self.in_flight.clear()
 
     def tick(self) -> None:
         # Overview and review hooks call tick() when the deck overview loads or
@@ -70,6 +77,9 @@ class ReviewTimeEvaluator:
         # completes. Otherwise, wait until enough uncovered cards have accumulated,
         # unless the scheduler returned fewer than LOOKAHEAD cards and this wave should
         # flush the end-of-queue leftovers.
+        if self.is_stopped:
+            return
+
         if not mw or not mw.col or mw.state not in {"overview", "review"}:
             return
 
@@ -174,23 +184,41 @@ class ReviewTimeEvaluator:
         return not is_card_fully_processed(card)
 
     async def run_batch(self, candidates: list[Card]) -> None:
+        if self.is_stopped:
+            return
+
         logger.info(f"Starting review-time evaluation wave for {len(candidates)} cards")
         results = await asyncio.gather(
             *[self.run_card_task(card) for card in candidates],
             return_exceptions=True,
         )
+        if self.is_stopped:
+            return
+
         if any(isinstance(result, OutOfCreditsError) for result in results):
             raise OutOfCreditsError()
 
     async def run_card_task(self, card: Card) -> None:
+        if self.is_stopped:
+            self.in_flight.discard(card.id)
+            return
+
         did_change = False
         try:
             did_change = await self.processor.process_note(
                 card.note(), deck_id=card.did, overwrite_fields=False
             )
         except OutOfCreditsError:
+            if self.is_stopped:
+                return
             raise
         except Exception as e:
+            if self.is_stopped:
+                logger.info(
+                    f"Stopped review-time card task {card.id} during profile cleanup"
+                )
+                return
+
             if isinstance(e, ClientFacingAPIError):
                 # Keep this below error level so expected per-card failures do not
                 # become Sentry events through the logging integration.
@@ -202,6 +230,9 @@ class ReviewTimeEvaluator:
         finally:
             self.in_flight.discard(card.id)
 
+        if self.is_stopped:
+            return
+
         run_on_main(
             lambda card_id=card.id,
             did_change=did_change: self.maybe_redraw_and_sparkle(card_id, did_change)
@@ -209,15 +240,23 @@ class ReviewTimeEvaluator:
 
     def on_complete(self, _: Any) -> None:
         self.wave_in_progress = False
+        if self.is_stopped:
+            return
         self.process_pending_tick()
 
     def on_complete_error(self, e: Exception) -> None:
         self.wave_in_progress = False
+        if self.is_stopped:
+            return
         if isinstance(e, OutOfCreditsError):
             app_state.update_subscription_state()
         self.process_pending_tick()
 
     def process_pending_tick(self) -> None:
+        if self.is_stopped:
+            self.pending_tick = False
+            return
+
         if not self.pending_tick:
             return
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -125,6 +125,31 @@ def test_profile_cleanup_closes_open_options_dialog(
     assert did_close
 
 
+def test_profile_cleanup_stops_review_time_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    did_stop = False
+
+    class FakeReviewTimeEvaluator:
+        def stop(self) -> None:
+            nonlocal did_stop
+            did_stop = True
+
+    monkeypatch.setattr(hooks, "_open_options_dialog", None)
+    monkeypatch.setattr(hooks, "_local_server", None)
+    monkeypatch.setattr(
+        hooks,
+        "_review_time_evaluator",
+        cast(Any, FakeReviewTimeEvaluator()),
+    )
+    monkeypatch.setattr(hooks, "cleanup_logger", lambda: None)
+
+    hooks.cleanup()
+
+    assert did_stop
+    assert vars(hooks)["_review_time_evaluator"] is None
+
+
 def test_addon_install_hook_cleans_up_current_addon(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_review_time_evaluator.py
+++ b/tests/test_review_time_evaluator.py
@@ -252,6 +252,27 @@ def test_tick_ignores_non_review_states(monkeypatch):
     assert not evaluator.wave_in_progress
 
 
+def test_tick_ignores_stopped_evaluator(monkeypatch):
+    started_batches = []
+    evaluator, _, review_time_evaluator = setup_review_time_evaluator(
+        monkeypatch,
+        current=MockCard(id=99),
+        queued=[MockCard(id=1)],
+    )
+    monkeypatch.setattr(
+        review_time_evaluator,
+        "run_async_in_background_with_sentry",
+        lambda *args, **kwargs: started_batches.append(args),
+    )
+
+    evaluator.stop()
+    evaluator.tick()
+
+    assert started_batches == []
+    assert evaluator.in_flight == set()
+    assert not evaluator.wave_in_progress
+
+
 def test_current_card_bypasses_top_off_gate(monkeypatch):
     started_batches = []
     queued = [MockCard(id=i, processed=True) for i in range(1, 11)]
@@ -294,6 +315,29 @@ def test_pending_tick_refires_after_completion(monkeypatch):
     assert evaluator.wave_in_progress
     assert evaluator.in_flight == {1}
     assert len(started_batches) == 1
+
+
+def test_stopped_evaluator_drops_pending_tick(monkeypatch):
+    started_batches = []
+    evaluator, _, review_time_evaluator = setup_review_time_evaluator(
+        monkeypatch,
+        current=MockCard(id=1),
+        queued=[],
+    )
+    monkeypatch.setattr(
+        review_time_evaluator,
+        "run_async_in_background_with_sentry",
+        lambda *args, **kwargs: started_batches.append(args),
+    )
+    evaluator.pending_tick = True
+
+    evaluator.stop()
+    evaluator.on_complete(None)
+
+    assert not evaluator.pending_tick
+    assert not evaluator.wave_in_progress
+    assert evaluator.in_flight == set()
+    assert started_batches == []
 
 
 def test_tick_clears_stale_pending_tick_when_starting_batch(monkeypatch):
@@ -390,3 +434,35 @@ async def test_run_card_task_logs_client_facing_errors_without_error_level(
         "Client-facing error prepping card 1: Try a different provider."
     ]
     assert len(redraws) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_card_task_suppresses_shutdown_errors(monkeypatch):
+    evaluator, _, review_time_evaluator = setup_review_time_evaluator(
+        monkeypatch,
+        current=MockCard(id=1),
+        queued=[],
+    )
+
+    class ClosingProcessor(MockProcessor):
+        async def process_note(self, *args, **kwargs) -> bool:
+            evaluator.stop()
+            raise RuntimeError("CollectionNotOpen")
+
+    evaluator.processor = ClosingProcessor()  # type: ignore[assignment]
+    evaluator.in_flight.add(1)
+    error_logs = []
+    info_logs = []
+    redraws = []
+    monkeypatch.setattr(review_time_evaluator.logger, "error", error_logs.append)
+    monkeypatch.setattr(review_time_evaluator.logger, "info", info_logs.append)
+    monkeypatch.setattr(
+        review_time_evaluator, "run_on_main", lambda work: redraws.append(work)
+    )
+
+    await evaluator.run_card_task(MockCard(id=1, did=10))
+
+    assert evaluator.in_flight == set()
+    assert error_logs == []
+    assert info_logs == ["Stopped review-time card task 1 during profile cleanup"]
+    assert redraws == []


### PR DESCRIPTION
## Summary
- Stop the review-time evaluator during profile cleanup before dropping the global reference.
- Prevent stopped review-time waves from replaying pending ticks, redrawing reviewer UI, or logging shutdown-time per-card failures at Sentry-captured error level.
- Add regression coverage for profile cleanup, stopped ticks, pending tick suppression, and shutdown-time card task errors.

## Root cause
Review-time generation could keep draining after profile close. If an active wave finished a network call after Anki had closed the collection, later note/media access could raise teardown errors like `CollectionNotOpen` and emit Sentry noise.

## Verification
- `make check-plugin`
- `source .venv/bin/activate && python -m pytest tests/test_review_time_evaluator.py tests/test_hooks.py`
- `source .venv/bin/activate && python -m pytest`
- `./scripts/build.sh anki-local` loaded Smart Notes without a startup traceback or failed-load dialog. Observed pre-existing local-environment noise: duplicate local server bind on `127.0.0.1:8766` and localhost `3000` status/feature-flag connection failures.

Claude review was attempted locally, but the CLI did not return final findings and had to be terminated after repeatedly streaming tool reads/thinking output.

## Agent session metadata
- Working directory: `/Users/michaelpiazza/development/smart_notes_all`
- Session ID: `019f2838-0a34-7f00-a946-fad32b30eeea`
