### PR TITLE
fix: display prompt generation validation errors

### DIFF
--- a/src/ui/prompt_dialog.py
+++ b/src/ui/prompt_dialog.py
@@ -42,7 +42,7 @@ from aqt import (
     mw,
 )
 
-from ..api_client import api
+from ..api_client import ClientFacingAPIError, api
 from ..app_state import (
     is_app_legacy,
     is_capacity_remaining,
@@ -705,7 +705,10 @@ class PromptDialog(QDialog):
             self.state.update({"prompt": prompt, "is_generating_prompt": False})
 
         def on_failure(e: Exception) -> None:
-            show_message_box(f"Failed to generate prompt: {e}")
+            if isinstance(e, ClientFacingAPIError):
+                show_message_box(str(e))
+            else:
+                show_message_box(f"Failed to generate prompt: {e}")
             self.state["is_generating_prompt"] = False
 
         run_async_in_background_with_sentry(generate_fn, on_success, on_failure)


### PR DESCRIPTION
## Summary
- display server-provided client-facing prompt-generation errors directly in the prompt dialog
- keep the generic `Failed to generate prompt:` wrapper for non-client-facing failures

## Why
The server now returns a user-facing 400 message for invalid generated prompts. The prompt dialog needs to show that message as-is so users see the actionable guidance instead of a generic failure prefix.

## Verification
- `make check-plugin`
- `python -m pytest`
- Anki UI verification with a temporary localhost stub returning the same `{ error }` response shape: the real prompt dialog displayed the exact message, cleared the loading state, and left the prompt unchanged.

## Agent session metadata
- Working directory: `/Users/michaelpiazza/development/smart_notes_all`
- Session ID: `019f0cb4-e484-7273-9e5c-68ff5f68b434`
