### PR TITLE
fix: guard unavailable Anki add-on hooks [ANK-426]

### DIFF
--- a/src/hooks.py
+++ b/src/hooks.py
@@ -530,9 +530,13 @@ def setup_hooks(processor: NoteProcessor):
     gui_hooks.main_window_did_init.append(on_main_window(processor))
     gui_hooks.profile_did_open.append(on_profile_did_open(processor))
     gui_hooks.profile_will_close.append(cleanup)
-    gui_hooks.addon_manager_will_install_addon.append(
-        on_addon_manager_will_install_addon
-    )
-    gui_hooks.addons_dialog_will_delete_addons.append(
-        on_addons_dialog_will_delete_addons
-    )
+
+    # These cleanup hooks were added in different Anki versions.
+    if hasattr(gui_hooks, "addon_manager_will_install_addon"):
+        gui_hooks.addon_manager_will_install_addon.append(
+            on_addon_manager_will_install_addon
+        )
+    if hasattr(gui_hooks, "addons_dialog_will_delete_addons"):
+        gui_hooks.addons_dialog_will_delete_addons.append(
+            on_addons_dialog_will_delete_addons
+        )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -185,6 +185,48 @@ def test_addon_delete_hook_cleans_up_current_addon(
     assert calls == ["cleanup"]
 
 
+def test_setup_hooks_supports_anki_without_addon_install_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_gui_hooks = _fake_gui_hooks(
+        addons_dialog_will_delete_addons=[],
+    )
+    monkeypatch.setattr(hooks, "gui_hooks", fake_gui_hooks)
+
+    hooks.setup_hooks(cast(NoteProcessor, object()))
+
+    assert fake_gui_hooks.addons_dialog_will_delete_addons == [
+        hooks.on_addons_dialog_will_delete_addons
+    ]
+
+
+def test_setup_hooks_supports_anki_without_addon_cleanup_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(hooks, "gui_hooks", _fake_gui_hooks())
+
+    hooks.setup_hooks(cast(NoteProcessor, object()))
+
+
+def test_setup_hooks_registers_available_addon_cleanup_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_gui_hooks = _fake_gui_hooks(
+        addon_manager_will_install_addon=[],
+        addons_dialog_will_delete_addons=[],
+    )
+    monkeypatch.setattr(hooks, "gui_hooks", fake_gui_hooks)
+
+    hooks.setup_hooks(cast(NoteProcessor, object()))
+
+    assert fake_gui_hooks.addon_manager_will_install_addon == [
+        hooks.on_addon_manager_will_install_addon
+    ]
+    assert fake_gui_hooks.addons_dialog_will_delete_addons == [
+        hooks.on_addons_dialog_will_delete_addons
+    ]
+
+
 def test_cleanup_before_addon_files_change_releases_non_ui_resources(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -208,3 +250,19 @@ def test_cleanup_before_addon_files_change_releases_non_ui_resources(
         "logger_cleanup",
     ]
     assert vars(hooks)["_local_server"] is None
+
+
+def _fake_gui_hooks(**addon_hooks: list[Any]) -> SimpleNamespace:
+    return SimpleNamespace(
+        browser_will_show_context_menu=[],
+        browser_sidebar_will_show_context_menu=[],
+        editor_did_init_buttons=[],
+        editor_will_show_context_menu=[],
+        overview_did_refresh=[],
+        reviewer_did_show_question=[],
+        reviewer_did_answer_card=[],
+        main_window_did_init=[],
+        profile_did_open=[],
+        profile_will_close=[],
+        **addon_hooks,
+    )


### PR DESCRIPTION
## Summary

- guard registration of Anki's add-on install/delete cleanup hooks when the running Anki version does not expose them
- preserve registration of whichever cleanup hook is available
- cover old and current Anki hook surfaces with focused regression tests

## Root cause

[APP-KT](https://rosebud-74.sentry.io/issues/ANKI-SMART-NOTES-APP-KT) showed Smart Notes 2.23.8/2.23.9 raising `AttributeError` during startup because `addon_manager_will_install_addon` was introduced in Anki 2.1.65, while Smart Notes supports older Anki versions and unconditionally accessed the hook.

The failure occurred after normal hook registration, so it did not indicate collection/data loss, but it displayed a startup error and prevented the add-on file-replacement cleanup hooks from registering.

Linear: [ANK-426](https://linear.app/anki-smart-notes/issue/ANK-426/fix-app-kt-old-anki-missing-add-on-install-hook)

## Verification

- red reproduction: old-Anki hook fixture failed on the original code with the production `AttributeError`
- `source .venv/bin/activate && python -m pytest tests/test_hooks.py` — 11 passed
- `source .venv/bin/activate && python -m pytest` — 199 passed
- `make check-plugin` — formatting, lint, and typechecking passed
- `make sandbox-local` with Anki 25.07.5 — Smart Notes loaded, the local server bound to `127.0.0.1:8766`, the settings dialog rendered, and logs contained no traceback, failed-load message, or hook error
- one Claude review found no functional issues; its test-ordering suggestion was addressed and the hook suite rerun

## Agent session metadata

- Working directory: `/Users/michaelpiazza/development/smart_notes_all`
- Session ID: `019f6ffb-b3f7-7020-a632-0de6824724db`
