### PR TITLE
fix: cap review-time generation waves at 10 cards

### DIFF
--- a/src/review_time_evaluator.py
+++ b/src/review_time_evaluator.py
@@ -19,7 +19,7 @@ along with Smart Notes.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
 import traceback
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 from anki.cards import Card, CardId
 from anki.scheduler.v3 import Scheduler
@@ -101,27 +101,31 @@ class ReviewTimeEvaluator:
 
         reviewer = mw.reviewer if mw.state == "review" else None
         current_card = reviewer.card if reviewer else None
-        current_card_candidates = (
-            [current_card]
+        current_card_candidate = (
+            current_card
             if current_card and self.is_card_eligible(current_card)
-            else []
+            else None
         )
         queued_card_candidates, hit_end_of_queue = self.get_queued_card_candidates(
-            existing_candidate_ids={card.id for card in current_card_candidates}
+            current_card_candidate
         )
 
         logger.debug(
-            f"Found {len(current_card_candidates)} eligible current card(s) and {len(queued_card_candidates)} eligible queued card(s) for review-time evaluation"
+            f"Current card eligible={current_card_candidate is not None}; found {len(queued_card_candidates)} eligible queued card(s) for review-time evaluation"
         )
 
-        candidates = current_card_candidates + queued_card_candidates
+        candidates = (
+            [current_card_candidate, *queued_card_candidates]
+            if current_card_candidate is not None
+            else queued_card_candidates
+        )
 
         if not candidates:
             logger.info("Zero eligible cards found for review-time evaluation")
             return
 
         if (
-            not current_card_candidates
+            current_card_candidate is None
             and len(queued_card_candidates) < MIN_BATCH_SIZE
             and not hit_end_of_queue
         ):
@@ -145,14 +149,16 @@ class ReviewTimeEvaluator:
         )
 
     def get_queued_card_candidates(
-        self, existing_candidate_ids: set[CardId]
+        self, current_card_candidate: Optional[Card]
     ) -> tuple[list[Card], bool]:
         if not mw or not mw.col:
             return ([], False)
 
         candidates: list[Card] = []
-        candidate_ids = set(existing_candidate_ids)
-        available_slots = MAX_WAVE_SIZE - len(existing_candidate_ids)
+        candidate_ids = (
+            {current_card_candidate.id} if current_card_candidate is not None else set()
+        )
+        available_slots = MAX_WAVE_SIZE - len(candidate_ids)
         scheduler = cast(Scheduler, mw.col.sched)
 
         queued_cards = scheduler.get_queued_cards(fetch_limit=LOOKAHEAD).cards

--- a/src/review_time_evaluator.py
+++ b/src/review_time_evaluator.py
@@ -38,6 +38,9 @@ from .utils.notes_utils import is_card_fully_processed
 # Number of upcoming scheduler cards to inspect on each review tick.
 LOOKAHEAD = 25
 
+# Maximum number of cards processed concurrently in one review-time wave.
+MAX_WAVE_SIZE = 10
+
 # Minimum number of uncovered queued cards required before firing a normal
 # top-off batch. Smaller batches still run when they flush the end of the queue.
 MIN_BATCH_SIZE = 5
@@ -149,6 +152,7 @@ class ReviewTimeEvaluator:
 
         candidates: list[Card] = []
         candidate_ids = set(existing_candidate_ids)
+        available_slots = MAX_WAVE_SIZE - len(existing_candidate_ids)
         scheduler = cast(Scheduler, mw.col.sched)
 
         queued_cards = scheduler.get_queued_cards(fetch_limit=LOOKAHEAD).cards
@@ -175,6 +179,8 @@ class ReviewTimeEvaluator:
 
             candidates.append(card)
             candidate_ids.add(card.id)
+            if len(candidates) >= available_slots:
+                break
 
         return (candidates, hit_end_of_queue)
 

--- a/tests/test_review_time_evaluator.py
+++ b/tests/test_review_time_evaluator.py
@@ -163,6 +163,48 @@ def test_tick_filters_in_flight_and_processed_cards(monkeypatch):
     assert started_batches[0][1] is False
 
 
+def test_tick_caps_wave_at_ten_cards_without_reducing_scheduler_lookahead(
+    monkeypatch,
+):
+    started_batches = []
+    evaluator, _, review_time_evaluator = setup_review_time_evaluator(
+        monkeypatch,
+        current=MockCard(id=100),
+        queued=[MockCard(id=i) for i in range(1, 26)],
+    )
+    monkeypatch.setattr(
+        review_time_evaluator,
+        "run_async_in_background_with_sentry",
+        lambda *args, **kwargs: started_batches.append(args),
+    )
+
+    evaluator.tick()
+
+    assert review_time_evaluator.mw.col.sched.fetch_limits == [25]
+    assert evaluator.in_flight == {100, *range(1, 10)}
+    assert len(started_batches) == 1
+
+
+def test_tick_caps_queued_only_wave_at_ten_cards(monkeypatch):
+    started_batches = []
+    evaluator, _, review_time_evaluator = setup_review_time_evaluator(
+        monkeypatch,
+        current=None,
+        queued=[MockCard(id=i) for i in range(1, 26)],
+        state="overview",
+    )
+    monkeypatch.setattr(
+        review_time_evaluator,
+        "run_async_in_background_with_sentry",
+        lambda *args, **kwargs: started_batches.append(args),
+    )
+
+    evaluator.tick()
+
+    assert evaluator.in_flight == set(range(1, 11))
+    assert len(started_batches) == 1
+
+
 def test_tick_skips_tiny_top_off_when_queue_has_more_cards(monkeypatch):
     started_batches = []
     queued = [

--- a/tests/test_review_time_evaluator.py
+++ b/tests/test_review_time_evaluator.py
@@ -109,8 +109,7 @@ def test_tick_sets_pending_tick_when_wave_in_progress(monkeypatch):
     assert evaluator.pending_tick
 
 
-def test_get_queued_card_candidates_does_not_mutate_existing_ids(monkeypatch):
-    existing_candidate_ids = {1}
+def test_get_queued_card_candidates_excludes_current_card(monkeypatch):
     evaluator, _, _ = setup_review_time_evaluator(
         monkeypatch,
         current=None,
@@ -122,13 +121,10 @@ def test_get_queued_card_candidates_does_not_mutate_existing_ids(monkeypatch):
     )
     evaluator.in_flight.add(4)
 
-    candidates, hit_end_of_queue = evaluator.get_queued_card_candidates(
-        existing_candidate_ids
-    )
+    candidates, hit_end_of_queue = evaluator.get_queued_card_candidates(MockCard(id=1))
 
     assert [card.id for card in candidates] == [2]
     assert hit_end_of_queue
-    assert existing_candidate_ids == {1}
 
 
 def test_tick_filters_in_flight_and_processed_cards(monkeypatch):


### PR DESCRIPTION
## Summary
- keep the scheduler scan depth at 25 cards
- cap each review-time generation wave at 10 cards, including the current card
- cover both current-card and queued-only wave limits with regression tests

## Root cause
The scheduler lookahead controlled both how far Smart Notes searched for eligible cards and how many cards it launched concurrently. A 25-card scan could therefore create a much larger generation fan-out than needed.

Separating the 25-card scan depth from the 10-card wave limit preserves the existing lookahead behavior while reducing peak concurrency.

## Verification
- `make check-plugin`
- `python -m pytest` — 201 passed
- Anki 25.07.5 sandbox startup smoke test — Smart Notes initialized, migrations completed, and the local add-on server bound without startup tracebacks
- Claude code review — no correctness issues; minor suggestions addressed

## Agent session metadata
- Working directory: `/Users/michaelpiazza/development/smart_notes_all`
- Session ID: `019f75a6-7d15-7163-bfea-f1853c36b47d`
